### PR TITLE
Bump cycles-client-java-spring version to 0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Cycles enforces budget reservations around guarded method executions using a **r
 <dependency>
     <groupId>io.runcycles</groupId>
     <artifactId>cycles-client-java-spring</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
 </dependency>
 ```
 


### PR DESCRIPTION
## Summary
This pull request updates the version of the cycles-client-java-spring dependency from 0.1.0 to 0.1.1 in the README documentation.

## Changes
- Updated the Maven dependency version in README.md to reflect the latest release (0.1.1)

## Notes
This is a documentation update to keep the README synchronized with the current stable version of the library.

https://claude.ai/code/session_01L6csPLeJCTVKdoGSkwm93i