### PR TITLE
Fix cycles-client-java-spring version to 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Cycles enforces budget reservations around guarded method executions using a **r
 <dependency>
     <groupId>io.runcycles</groupId>
     <artifactId>cycles-client-java-spring</artifactId>
-    <version>0.1.1</version>
+    <version>0.1.0</version>
 </dependency>
 ```
 

--- a/cycles-demo-client-java-spring/pom.xml
+++ b/cycles-demo-client-java-spring/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>io.runcycles</groupId>
             <artifactId>cycles-client-java-spring</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Update README and demo project pom.xml to reference version 0.1.0, which matches what is published in the Maven repo.

https://claude.ai/code/session_01F3TeMJpXSEWFZ8uiRDvPzW