### PR TITLE
Add CI workflow for automated testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Run tests
+        working-directory: cycles-client-java-spring
+        run: mvn -B test


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions CI workflow to automatically run tests on push and pull requests.

## Key Changes
- Added `.github/workflows/ci.yml` workflow configuration that:
  - Triggers on push and pull request events
  - Sets up JDK 21 (Temurin distribution) with Maven caching
  - Runs Maven tests in the `cycles-client-java-spring` directory

## Implementation Details
- Uses `actions/checkout@v5` for repository access
- Uses `actions/setup-java@v5` with Maven cache enabled for faster builds
- Runs `mvn -B test` to execute the test suite in batch mode
- Minimal permissions configured (contents: read only)

https://claude.ai/code/session_016fgYx22kSabUKKRtK2pmg9