### PR TITLE
Add demo module compilation to CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,11 @@ jobs:
       - name: Run tests and verify coverage
         working-directory: cycles-client-java-spring
         run: mvn -B verify
+
+      - name: Install starter to local repo
+        working-directory: cycles-client-java-spring
+        run: mvn -B install -DskipTests
+
+      - name: Compile demo module
+        working-directory: cycles-demo-client-java-spring
+        run: mvn -B compile


### PR DESCRIPTION
The demo depends on the starter via Maven coordinates, so install the starter to the local repo first, then compile the demo. This catches compilation breaks in the demo before they merge.

https://claude.ai/code/session_016fgYx22kSabUKKRtK2pmg9