### PR TITLE
Update documentation with correct module names and add demo client

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,10 +7,11 @@ The session start hook (`.claude/session-start-maven-proxy.sh`) automatically se
 
 ```bash
 # Use this:
-mvn-proxy -B verify --file cycles-spring-boot-starter/pom.xml
+mvn-proxy -B verify --file cycles-client-java-spring/pom.xml
+mvn-proxy -B verify --file cycles-demo-client-java-spring/pom.xml
 
 # NOT this (will fail with DNS/proxy errors):
-mvn -B verify --file cycles-spring-boot-starter/pom.xml
+mvn -B verify --file cycles-client-java-spring/pom.xml
 ```
 
 **Why:** The remote environment routes traffic through an egress proxy. Java's `JAVA_TOOL_OPTIONS`


### PR DESCRIPTION
## Summary
Updated the CLAUDE.md documentation to reflect the correct Java module names and added instructions for building the demo client module.

## Key Changes
- Updated module references from `cycles-spring-boot-starter` to `cycles-client-java-spring` to match the actual project structure
- Added build instructions for the `cycles-demo-client-java-spring` module
- Corrected the example command in the "NOT this" section to use the updated module name

## Details
The documentation previously referenced an incorrect module name (`cycles-spring-boot-starter`) in the Maven proxy usage examples. This has been corrected to point to the actual module (`cycles-client-java-spring`). Additionally, a new line was added to document how to build the demo client module using the same proxy setup.

https://claude.ai/code/session_01CRrhdFFEnvfpwKp1APJPWM