### PR TITLE
Add API key creation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ cycles:
   app: my-app
 ```
 
-> **Need an API key?** API keys are created via the Cycles Admin Server (port 7979). See the [deployment guide](https://docs.runcycles.io/quickstart/deploying-the-full-cycles-stack#step-3-create-an-api-key) to create one, or run:
+> **Need an API key?** API keys are created via the Cycles Admin Server (port 7979). See the [deployment guide](https://runcycles.io/quickstart/deploying-the-full-cycles-stack#step-3-create-an-api-key) to create one, or run:
 > ```bash
 > curl -s -X POST http://localhost:7979/v1/admin/api-keys \
 >   -H "Content-Type: application/json" \
 >   -H "X-Admin-API-Key: admin-bootstrap-key" \
 >   -d '{"tenant_id":"acme-corp","name":"dev-key","permissions":["reservations:create","reservations:commit","reservations:release","reservations:extend","reservations:list","balances:read","decide","events:create"]}' | jq -r '.key_secret'
 > ```
-> The key (e.g. `cyc_live_abc123...`) is shown only once — save it immediately. For key rotation and lifecycle details, see [API Key Management](https://docs.runcycles.io/how-to/api-key-management-in-cycles).
+> The key (e.g. `cyc_live_abc123...`) is shown only once — save it immediately. For key rotation and lifecycle details, see [API Key Management](https://runcycles.io/how-to/api-key-management-in-cycles).
 
 ### 3. Annotate your method
 
@@ -480,7 +480,7 @@ cycles-spring-boot-starter/
 
 The demo app at `cycles-demo-client-java-spring/` showcases every major feature of the starter.
 
-**Prerequisites:** You need a running Cycles stack with a tenant, API key, and budget. Follow the [deployment guide](https://docs.runcycles.io/quickstart/deploying-the-full-cycles-stack) to set up the `acme-corp` tenant used by the demo. Then:
+**Prerequisites:** You need a running Cycles stack with a tenant, API key, and budget. Follow the [deployment guide](https://runcycles.io/quickstart/deploying-the-full-cycles-stack) to set up the `acme-corp` tenant used by the demo. Then:
 
 ```bash
 cd cycles-demo-client-java-spring

--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ cycles:
   app: my-app
 ```
 
+> **Need an API key?** API keys are created via the Cycles Admin Server (port 7979). See the [deployment guide](https://docs.runcycles.io/quickstart/deploying-the-full-cycles-stack#step-3-create-an-api-key) to create one, or run:
+> ```bash
+> curl -s -X POST http://localhost:7979/v1/admin/api-keys \
+>   -H "Content-Type: application/json" \
+>   -H "X-Admin-API-Key: admin-bootstrap-key" \
+>   -d '{"tenant_id":"acme-corp","name":"dev-key","permissions":["reservations:create","reservations:commit","reservations:release","reservations:extend","reservations:list","balances:read","decide","events:create"]}' | jq -r '.key_secret'
+> ```
+> The key (e.g. `cyc_live_abc123...`) is shown only once — save it immediately. For key rotation and lifecycle details, see [API Key Management](https://docs.runcycles.io/how-to/api-key-management-in-cycles).
+
 ### 3. Annotate your method
 
 ```java

--- a/cycles-demo-client-java-spring/src/main/resources/application.yml
+++ b/cycles-demo-client-java-spring/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
 #
 # Before running the demo, you need a Cycles stack with a tenant, API key,
 # and budget. Follow the deployment guide:
-#   https://docs.runcycles.io/quickstart/deploying-the-full-cycles-stack
+#   https://runcycles.io/quickstart/deploying-the-full-cycles-stack
 #
 # Quick setup (after the stack is running):
 #   1. Create tenant "acme-corp" via the admin API


### PR DESCRIPTION
## Summary
Added comprehensive documentation for creating API keys in the Cycles Admin Server to the README, including a curl command example and important security notes.

## Changes
- Added a new section with instructions for obtaining an API key via the Cycles Admin Server (port 7979)
- Included a ready-to-use curl command that demonstrates how to create an API key with the necessary permissions for common operations (reservations, balances, decide, events)
- Added warning about API key visibility and guidance to save the key immediately upon creation
- Linked to the deployment guide and API Key Management documentation for additional context

## Details
This addition helps users quickly get started by providing the exact steps needed to create an API key, reducing friction in the onboarding process. The example includes all standard permissions needed for typical Cycles operations.

https://claude.ai/code/session_01HftF1nebzvUzQy4y4zGJk6