### PR TITLE
Document and demo per-annotation budget scope targeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,16 +120,14 @@ All properties are configured in your project's `application.yml` (or `applicati
 
 ```yaml
 cycles:
-  api-key: ""              # X-Cycles-API-Key header (required)
-  base-url: ""             # Cycles server URL (required)
+  api-key: ${CYCLES_API_KEY}          # X-Cycles-API-Key header (required)
+  base-url: http://localhost:7878     # Cycles server URL (required)
 
-  # Default subject fields (can be overridden per-annotation)
-  tenant: ""
-  workspace: ""
-  app: ""
-  workflow: ""
-  agent: ""
-  toolset: ""
+  # Default subject fields (applied to all @Cycles methods unless overridden per-annotation)
+  tenant: acme-corp
+  workspace: development
+  app: my-app
+  # workflow, agent, toolset — omit if not needed globally
 
   # HTTP client settings
   http:
@@ -167,6 +165,31 @@ cycles:
 | `workflow` | No | `""` | Override workflow |
 | `agent` | No | `""` | Override agent |
 | `toolset` | No | `""` | Override toolset |
+
+### Per-Annotation Subject Overrides
+
+Any subject field set on `@Cycles` overrides the config default for that method call. This changes which budget scope the reservation targets.
+
+```java
+// Given config: tenant=acme-corp, workspace=development, app=my-app
+
+// Uses ALL config defaults.
+// Budget scope: tenant:acme-corp/workspace:development/app:my-app
+@Cycles("1000")
+public String defaultScope(String input) { ... }
+
+// Overrides workspace → targets the STAGING budget, not development.
+// Budget scope: tenant:acme-corp/workspace:staging/app:my-app
+@Cycles(value = "1000", workspace = "staging")
+public String stagingScope(String input) { ... }
+
+// Overrides workspace AND app → targets production billing budget.
+// Budget scope: tenant:acme-corp/workspace:production/app:billing-service
+@Cycles(value = "#amount", workspace = "production", app = "billing-service")
+public String productionBilling(int amount) { ... }
+```
+
+> **Budget scopes are independent.** `tenant:acme-corp/workspace:development` and `tenant:acme-corp/workspace:staging` have separate budgets. A reservation must pass budget checks at **all** affected scope levels in the hierarchy (e.g., both `tenant:acme-corp` and `tenant:acme-corp/workspace:staging`).
 
 ### SpEL Expressions
 
@@ -498,7 +521,7 @@ Hit `GET http://localhost:7955/api/demo/index` for a full listing of all endpoin
 
 Key demo scenarios:
 - **`/api/llm/*`** — `@Cycles` annotation with `CyclesContextHolder`, `CyclesMetrics`, and `commitMetadata`
-- **`/api/demo/annotation/*`** — Annotation variations: `unit=TOKENS`, `unit=CREDITS`, `overagePolicy`, `ttlMs`/`gracePeriodMs`, `dryRun`, `dimensions`, `workflow`/`agent`
+- **`/api/demo/annotation/*`** — Annotation variations: per-annotation budget targeting (`workspace`/`app` override), `unit=TOKENS`, `unit=CREDITS`, `overagePolicy`, `ttlMs`/`gracePeriodMs`, `dryRun`, `dimensions`, `workflow`/`agent`
 - **`/api/demo/client/*`** — Programmatic `CyclesClient` usage: reserve/commit, reserve/release, preflight `decide()`, `getBalances()`, `listReservations()`
 - **`/api/demo/events/*`** — Standalone events via `createEvent()` (direct debit without reservation)
 

--- a/cycles-demo-client-java-spring/src/main/java/io/runcycles/demo/client/spring/controller/DemoController.java
+++ b/cycles-demo-client-java-spring/src/main/java/io/runcycles/demo/client/spring/controller/DemoController.java
@@ -86,6 +86,25 @@ public class DemoController {
         return ResponseEntity.ok(response);
     }
 
+    @PostMapping("/annotation/budget-targeting")
+    public ResponseEntity<Map<String, Object>> annotationBudgetTargeting(
+            @RequestParam(defaultValue = "500") int amount) {
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("scenario", "@Cycles with per-annotation workspace/app override — targets staging budget scope instead of development");
+        response.put("annotationConfig", Map.of(
+                "estimate", "#amount",
+                "workspace", "staging",
+                "app", "qa-runner",
+                "actionKind", "test.execution",
+                "actionName", "integration-test"));
+        response.put("configDefaults", Map.of("tenant", "acme-corp", "workspace", "development", "app", "demo"));
+        response.put("resolvedScope", "tenant:acme-corp/workspace:staging/app:qa-runner");
+        response.put("result", annotationShowcaseService.processForStagingBudget(amount));
+        response.put("note", "Config sets workspace=development, but this annotation overrides to workspace=staging. " +
+                "Budget is checked against the staging scope, not development.");
+        return ResponseEntity.ok(response);
+    }
+
     @PostMapping("/annotation/overdraft")
     public ResponseEntity<Map<String, Object>> annotationOverdraft(
             @RequestParam(defaultValue = "1000") int amount) {
@@ -219,6 +238,9 @@ public class DemoController {
         endpoints.add(endpointInfo("POST", "/api/demo/annotation/credits?creditAmount=100",
                 "@Cycles with unit=CREDITS, workflow/agent, dimensions",
                 "curl -X POST " + base + "/api/demo/annotation/credits?creditAmount=100"));
+        endpoints.add(endpointInfo("POST", "/api/demo/annotation/budget-targeting?amount=500",
+                "@Cycles with workspace/app override — targets staging budget instead of development",
+                "curl -X POST " + base + "/api/demo/annotation/budget-targeting?amount=500"));
         endpoints.add(endpointInfo("POST", "/api/demo/annotation/overdraft?amount=1000",
                 "@Cycles with overagePolicy=ALLOW_WITH_OVERDRAFT",
                 "curl -X POST " + base + "/api/demo/annotation/overdraft?amount=1000"));

--- a/cycles-demo-client-java-spring/src/main/java/io/runcycles/demo/client/spring/service/AnnotationShowcaseService.java
+++ b/cycles-demo-client-java-spring/src/main/java/io/runcycles/demo/client/spring/service/AnnotationShowcaseService.java
@@ -91,6 +91,29 @@ public class AnnotationShowcaseService {
     }
 
     /**
+     * Demonstrates: per-annotation subject field override for budget scope targeting.
+     *
+     * Config sets workspace = "development" and app = "demo", but this method overrides
+     * them to workspace = "staging" and app = "qa-runner". This changes which budget scope
+     * the reservation is checked against:
+     *
+     *   Config defaults  → tenant:acme-corp/workspace:development/app:demo
+     *   This method      → tenant:acme-corp/workspace:staging/app:qa-runner
+     *
+     * Each scope has an independent budget. Overriding subject fields lets different methods
+     * consume from different budgets without changing the global configuration.
+     */
+    @Cycles(estimate = "#amount",
+            workspace = "staging",
+            app = "qa-runner",
+            actionKind = "test.execution",
+            actionName = "integration-test")
+    public String processForStagingBudget(int amount) {
+        LOG.info("Processing against STAGING budget scope: amount={}", amount);
+        return "Executed against staging budget (workspace=staging, app=qa-runner) with amount " + amount;
+    }
+
+    /**
      * Demonstrates: overagePolicy = ALLOW_WITH_OVERDRAFT, separate actual expression.
      * When the budget is insufficient, the server allows the operation and records overdraft debt
      * instead of rejecting. The actual cost is computed from the result length.


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation and a working demo for per-annotation subject field overrides in the `@Cycles` annotation. It clarifies how developers can target different budget scopes by overriding `workspace`, `app`, `workflow`, `agent`, or `toolset` at the method level, independent of global configuration defaults.

## Key Changes

- **README.md updates:**
  - Replaced empty placeholder config values with realistic examples (`${CYCLES_API_KEY}`, `http://localhost:7878`, `acme-corp`, `development`, `my-app`)
  - Clarified that subject fields are "applied to all @Cycles methods unless overridden per-annotation"
  - Added new "Per-Annotation Subject Overrides" section with three concrete code examples showing how workspace/app overrides change the budget scope
  - Explained budget scope independence and hierarchy (e.g., both `tenant:acme-corp` and `tenant:acme-corp/workspace:staging` must pass checks)
  - Updated demo endpoint description to mention per-annotation budget targeting

- **AnnotationShowcaseService.java:**
  - Added `processForStagingBudget()` method demonstrating workspace and app overrides
  - Method targets `staging` workspace and `qa-runner` app instead of config defaults (`development` and `demo`)
  - Includes detailed JavaDoc explaining the budget scope change and use case

- **DemoController.java:**
  - Added `/api/demo/annotation/budget-targeting` POST endpoint
  - Returns structured response showing config defaults, annotation overrides, resolved scope, and execution result
  - Includes explanatory note about the override behavior
  - Updated `/api/demo/index` endpoint listing to include the new budget-targeting scenario

## Implementation Details

The changes demonstrate that per-annotation overrides work at the method level without requiring configuration changes, enabling different methods to consume from independent budget scopes. This is particularly useful for multi-tenant or multi-environment applications where different code paths should be metered against different budgets.

https://claude.ai/code/session_01HZ5cZ4DX66sDbrmHdBFQMc