### PR TITLE
Add documentation links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,12 @@ This starter implements the [Cycles Protocol v0](https://github.com/runcycles/cy
 
 If you are using WebFlux, do not rely on `CyclesContextHolder` inside reactive chains. This is a known design constraint for v0 — the library targets Spring MVC and blocking Spring AI workloads.
 
+## Documentation
+
+- [Cycles Documentation](https://runcycles.io) — full docs site
+- [Spring Boot Quickstart](https://runcycles.io/quickstart/getting-started-with-the-cycles-spring-boot-starter) — getting started guide
+- [Spring Client Configuration Reference](https://runcycles.io/configuration/client-configuration-reference-for-cycles-spring-boot-starter) — all configuration options
+
 ## License
 
 Apache 2.0


### PR DESCRIPTION
## Summary
Added a new Documentation section to the README with links to the Cycles Protocol documentation and related guides.

## Changes
- Added a new "Documentation" section in the README with three key resource links:
  - Link to the main Cycles Documentation site (https://runcycles.io)
  - Link to the Spring Boot Quickstart guide for getting started
  - Link to the Spring Client Configuration Reference for configuration options

## Details
The documentation section is positioned after the WebFlux usage note and before the License section, making it easily discoverable for users looking for additional resources and configuration guidance.

https://claude.ai/code/session_01NEcAqmfZHsZV9WEZXNofWY