### PR TITLE
Claude/analyze spring issue 29 v biy9

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ public String generateText(String prompt, int tokens) { ... }
 
 | Scenario | Outcome | Detail |
 |---|---|---|
-| Reservation denied (409) | **Neither** | `CyclesProtocolException` thrown; method never executes |
+| Reservation denied | **Neither** | `CyclesProtocolException` thrown; method never executes. Error may be `BUDGET_EXCEEDED`, `OVERDRAFT_LIMIT_EXCEEDED`, or `DEBT_OUTSTANDING` |
 | `dryRun = true`, any decision | **Neither** | Returns `DryRunResult` or throws; no real reservation created |
 | Method returns successfully | **Commit** | Actual amount charged; unused remainder auto-released |
 | Method throws any exception | **Release** | Full reserved amount returned to budget; exception re-thrown |
@@ -110,6 +110,7 @@ public String generateText(String prompt, int tokens) { ... }
 | Commit fails (non-retryable 4xx) | **Release** | Reservation released after non-retryable client error |
 | Commit gets RESERVATION_EXPIRED | **Neither** | Server already reclaimed budget on TTL expiry |
 | Commit gets RESERVATION_FINALIZED | **Neither** | Already committed or released (idempotent replay) |
+| Commit gets IDEMPOTENCY_MISMATCH | **Neither** | Previous commit already processed; no release attempted |
 
 All exceptions from the guarded method trigger release — no distinction between checked and unchecked exceptions.
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,23 @@ public String generateText(String prompt, int tokens) { ... }
 └─────────────────────────────────────────────────────────────────┘
 ```
 
+### Budget outcome by scenario
+
+| Scenario | Outcome | Detail |
+|---|---|---|
+| Reservation denied (409) | **Neither** | `CyclesProtocolException` thrown; method never executes |
+| `dryRun = true`, any decision | **Neither** | Returns `DryRunResult` or throws; no real reservation created |
+| Method returns successfully | **Commit** | Actual amount charged; unused remainder auto-released |
+| Method throws any exception | **Release** | Full reserved amount returned to budget; exception re-thrown |
+| Commit fails (5xx / network) | **Retry** | Exponential backoff; see `cycles.retry.*` config |
+| Commit fails (non-retryable 4xx) | **Release** | Reservation released after non-retryable client error |
+| Commit gets RESERVATION_EXPIRED | **Neither** | Server already reclaimed budget on TTL expiry |
+| Commit gets RESERVATION_FINALIZED | **Neither** | Already committed or released (idempotent replay) |
+
+All exceptions from the guarded method trigger release — no distinction between checked and unchecked exceptions.
+
+See [How Reserve-Commit Works](https://runcycles.io/protocol/how-reserve-commit-works-in-cycles) for the full protocol-level explanation.
+
 ### Decisions
 
 The Cycles server returns one of three decisions on reservation:


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><p>All done. Here's what was added across 4 repos:</p>
<p><strong>Budget lifecycle outcome table</strong> added to all three client SDK READMEs with consistent structure covering all 8 scenarios:</p>

Scenario | Outcome
-- | --
Reservation denied (409) | Neither — exception thrown, method never runs
Dry-run | Neither — no real reservation
Method succeeds | Commit — actual charged, remainder auto-released
Method throws | Release — full amount returned
Commit fails (transient) | Retry with exponential backoff
Commit fails (4xx) | Release
RESERVATION_EXPIRED | Neither — server reclaimed
RESERVATION_FINALIZED | Neither — idempotent


<p><strong>SDK cross-reference</strong> added to the main docs <code>how-reserve-commit-works-in-cycles.md</code> pointing readers to each SDK's outcome table.</p>
<p>Repos updated:</p>
<ul>
<li><code>cycles-spring-boot-starter</code> — table after ASCII diagram</li>
<li><code>cycles-client-typescript</code> — new "Budget lifecycle" subsection with streaming note</li>
<li><code>cycles-client-python</code> — new "Budget lifecycle" subsection</li>
<li><code>docs</code> — SDK tip callout in protocol lifecycle page</li>
</ul></body></html><!--EndFragment-->
</body>
</html>