### PR TITLE
chore: bump version to 0.2.0 for protocol v0.1.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Cycles enforces budget reservations around guarded method executions using a **r
 <dependency>
     <groupId>io.runcycles</groupId>
     <artifactId>cycles-client-java-spring</artifactId>
-    <version>0.1.1</version>
+    <version>0.2.0</version>
 </dependency>
 ```
 

--- a/cycles-client-java-spring/pom.xml
+++ b/cycles-client-java-spring/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.runcycles</groupId>
     <artifactId>cycles-client-java-spring</artifactId>
-    <version>0.1.1</version>
+    <version>0.2.0</version>
     <packaging>jar</packaging>
 
     <name>Cycles Client Java Spring</name>

--- a/cycles-demo-client-java-spring/pom.xml
+++ b/cycles-demo-client-java-spring/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.example</groupId>
     <artifactId>cycles-demo-client-java-spring</artifactId>
-    <version>0.1.1</version>
+    <version>0.2.0</version>
     <packaging>jar</packaging>
 
     <name>Cycles demo client for JAVA Spring</name>
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>io.runcycles</groupId>
             <artifactId>cycles-client-java-spring</artifactId>
-            <version>0.1.1</version>
+            <version>0.2.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary
- Bump version from 0.1.1 to 0.2.0 to reflect protocol spec v0.1.24 changes (new error codes, `charged` field on EventCreateResponse)
- Files changed\n- `cycles-client-java-spring/pom.xml` — project version\n- `cycles-demo-client-java-spring/pom.xml` — project version + dependency version
- `README.md` — dependency example version

https://claude.ai/code/session_015Gqqb6uHu7M6KgjhSMX8qo