### PR TITLE
Refactor CI workflow to use shared reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,30 +7,10 @@ on:
     branches: [main]
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: '21'
-          cache: maven
-
-      - name: Run tests and verify coverage
-        working-directory: cycles-client-java-spring
-        run: mvn -B verify
-
-      - name: Install starter to local repo
-        working-directory: cycles-client-java-spring
-        run: mvn -B install -DskipTests
-
-      - name: Compile demo module
-        working-directory: cycles-demo-client-java-spring
-        run: mvn -B compile
+  ci:
+    uses: runcycles/.github/.github/workflows/ci-java.yml@main
+    with:
+      pom-file: cycles-client-java-spring/pom.xml
+      extra-steps: true
+      extra-pom-install: cycles-client-java-spring/pom.xml
+      extra-pom-compile: cycles-demo-client-java-spring/pom.xml


### PR DESCRIPTION
## Summary
Refactored the CI workflow to use a shared reusable workflow from the `.github` repository instead of maintaining duplicate workflow logic.

## Key Changes
- Replaced inline CI job steps with a call to the shared `runcycles/.github/.github/workflows/ci-java.yml@main` reusable workflow
- Simplified workflow configuration by delegating Java setup, testing, and compilation steps to the shared workflow
- Configured the shared workflow with project-specific parameters:
  - `pom-file`: Points to the main Spring client module (`cycles-client-java-spring/pom.xml`)
  - `extra-steps`: Enabled to support additional build steps
  - `extra-pom-install`: Configured to install the Spring client starter to local repository
  - `extra-pom-compile`: Configured to compile the demo module (`cycles-demo-client-java-spring/pom.xml`)

## Benefits
- Reduces workflow maintenance burden by centralizing CI logic
- Ensures consistency across repositories using the same CI patterns
- Makes it easier to update CI/CD practices across multiple projects

https://claude.ai/code/session_01EGLQU8Z1d5cbbeqfYdV16a