### PR TITLE
ci: add explicit least-privilege permissions to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     uses: runcycles/.github/.github/workflows/ci-java.yml@main


### PR DESCRIPTION
## Summary
- CodeQL flagged `actions/missing-workflow-permissions` (medium) on `ci.yml`.
- Adds `permissions: contents: read` at the top level.
- Same one-line addition rolling out across the org.

## Test plan
- [ ] CI green on this PR.
- [ ] After merge, confirm the medium alert auto-closes in Security tab.