### PR TITLE
fix(demo): eliminate reflected-XSS surface in /api/llm/generate

### DIFF
--- a/cycles-demo-client-java-spring/src/main/java/io/runcycles/demo/client/spring/controller/LlmController.java
+++ b/cycles-demo-client-java-spring/src/main/java/io/runcycles/demo/client/spring/controller/LlmController.java
@@ -20,10 +20,18 @@ public class LlmController {
     private LlmService llmService;
 
     @PostMapping("/generate")
-    public String generate(
+    public ResponseEntity<Map<String, Object>> generate(
             @RequestParam String prompt,
             @RequestParam int tokens) {
-        return llmService.generateText(prompt, tokens);
+        // Wrap in a JSON body so the user-supplied prompt — which the LLM
+        // typically echoes back — is serialized as a JSON string rather
+        // than streamed raw as text/plain. Eliminates the reflected-XSS
+        // surface that CodeQL (java/xss) flags on the bare `String` return.
+        String result = llmService.generateText(prompt, tokens);
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("prompt", prompt);
+        body.put("response", result);
+        return ResponseEntity.ok(body);
     }
     @PostMapping ("/chat")
     public ResponseEntity<Map<String,Object>> handleChat(@RequestBody Map<String,Object> request) {


### PR DESCRIPTION
## Summary
CodeQL (`java/xss`, high) flagged `LlmController.generate()` on line 25-26 of `cycles-demo-client-java-spring/src/main/java/io/runcycles/demo/client/spring/controller/LlmController.java`: a bare `String` return from `llmService.generateText(prompt, tokens)` where `prompt` is a user-supplied `@RequestParam`.

LLM responses typically echo the prompt back. Spring's `StringHttpMessageConverter` ships the response as `text/plain` — safe *by default*, but a browser honoring a forced `text/html` response, or sniffing, can execute reflected script content.

**Fix:** return `ResponseEntity<Map<String, Object>>` wrapped in JSON, matching the sibling `/chat` endpoint. Jackson serializes the prompt/response as escaped JSON strings; `application/json` Content-Type rules out HTML rendering.

## Scope
Demo module only (`cycles-demo-client-java-spring`, `groupId=com.example`, not published to Maven Central). But anyone running the demo locally was exposed, so this is a real fix — not a won't-fix dismissal.

## Response shape change (breaking for raw-string consumers of `/api/llm/generate`)
Before:
```
POST /api/llm/generate?prompt=hello&tokens=100
→ 200 OK text/plain
"Hello! How can I help you today?"
```

After:
```
POST /api/llm/generate?prompt=hello&tokens=100
→ 200 OK application/json
{"prompt": "hello", "response": "Hello! How can I help you today?"}
```

The demo's self-documenting endpoint listing at `/api/demo/index` references this endpoint but doesn't encode response shape, so no doc update needed. The sibling `/chat` method already uses the same shape, so any demo consumer already handles it.

## Test plan
- [x] `mvn compile -DskipTests` in the demo module passes.
- [ ] CI green on this PR.
- [ ] After merge, confirm the high `java/xss` alert auto-closes in Security tab.