### PR TITLE
fix(client): evaluate SpEL on @Cycles subject fields (#49)

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -245,3 +245,14 @@ Since `toMap()` includes all non-null fields, requests built via the typed DTO a
 The client is **fully protocol-conformant** with the Cycles Protocol v0.1.23 OpenAPI spec. All 9 endpoints, 6 request schemas, 10 response schemas, 5 enum types, and all nested object serializations match the spec exactly. JSON field names use correct snake_case mapping throughout. Auth headers, idempotency handling, and subject validation all follow spec normative rules.
 
 Three low-severity gaps identified (response header capture, typed DTO validation, default value handling) — none are protocol violations; all are quality-of-life improvements for client consumers.
+
+---
+
+## Changelog
+
+### 2026-04-27 — Issue #49: SpEL on `@Cycles` subject fields + BeanPostProcessor warning
+
+- `CyclesExpressionEvaluator.evaluateString` resolves SpEL on `@Cycles` subject fields (`tenant`, `workspace`, `app`, `workflow`, `agent`, `toolset`) when the annotation value's first non-whitespace character is `#`. Literal values (e.g. `workspace = "production"`) bypass the parser and remain unchanged — fully backward-compatible. `#result` is intentionally not exposed because subject fields are resolved before the guarded method runs.
+- `CyclesRequestBuilderService` gains a context-aware `buildReservation` overload `(Cycles, long, String, String, Map, Method, Object[], Object)` that the AOP path uses. The existing 5-arg overload delegates with `null` invocation context (literal-only), so programmatic callers (`buildDecision`, `buildEvent`) keep their previous semantics.
+- `CyclesAutoConfiguration#cyclesSelfInvocationDetector` is now `static`, eliminating the Spring startup warning *"Bean ... is not eligible for getting processed by all BeanPostProcessors"* and ensuring the configuration class is properly post-processed.
+- New tests: `CyclesExpressionEvaluatorTest.EvaluateString` (literal/null/blank/`#var`/nested/safe-nav/non-String/leading-whitespace) and `CyclesRequestBuilderServiceTest.BuildReservationSpel` (end-to-end resolution of `@Cycles(workspace = "#workspaceId")` with fallback to resolver on null).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/).
 
+## [0.2.1] - 2026-04-27
+
+### Fixed
+
+- Evaluate SpEL on `@Cycles` subject fields (`tenant`, `workspace`, `app`, `workflow`, `agent`, `toolset`) when the value's first non-whitespace character is `#`. Previously the literal expression string was sent to the server, producing a 400 `INVALID_REQUEST`. Literal values are unchanged. ([#49](https://github.com/runcycles/cycles-spring-boot-starter/issues/49))
+- Make `CyclesAutoConfiguration#cyclesSelfInvocationDetector` a `static` `@Bean` factory method, eliminating the Spring startup warning *"Bean ... is not eligible for getting processed by all BeanPostProcessors"*. ([#49](https://github.com/runcycles/cycles-spring-boot-starter/issues/49))
+
+### Changed
+
+- **Behavior change:** A SpEL expression on a `@Cycles` subject field that fails to **parse** (e.g. `#((bad`) or fails to **evaluate against actual values** (e.g. invalid property access) now surfaces at AOP entry as `ParseException` / `SpelEvaluationException` instead of producing a malformed reservation request. References to undefined variables still resolve to `null` and fall through to the config / resolver bean chain, matching `#req?.workspaceId` semantics.
+- `CyclesExpressionEvaluator` caches parsed `Expression` instances per raw expression string, removing the per-invocation parse cost on hot `@Cycles` paths.
+
 ## [0.2.0] - 2026-03-24
 
 Bug fixes, support 0.1.24 protocol spec.
@@ -74,6 +86,7 @@ Initial public release of cycles-client-java-spring.
 
 - Fix `UNAUTHORIZED` HTTP status code and enhance dry-run documentation ([#14](https://github.com/runcycles/cycles-spring-boot-starter/pull/14))
 
+[0.2.1]: https://github.com/runcycles/cycles-spring-boot-starter/releases/tag/v0.2.1
 [0.2.0]: https://github.com/runcycles/cycles-spring-boot-starter/releases/tag/v0.2.0
 [0.1.1]: https://github.com/runcycles/cycles-spring-boot-starter/releases/tag/v0.1.1
 [0.1.0]: https://github.com/runcycles/cycles-spring-boot-starter/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Cycles enforces budget reservations around guarded method executions using a **r
 <dependency>
     <groupId>io.runcycles</groupId>
     <artifactId>cycles-client-java-spring</artifactId>
-    <version>0.2.0</version>
+    <version>0.2.1</version>
 </dependency>
 ```
 
@@ -233,6 +233,29 @@ Examples:
 // With explicit actual
 @Cycles(value = "#p1 * 10", actual = "#result.length() * 5")
 ```
+
+#### SpEL on subject fields
+
+The subject fields `tenant`, `workspace`, `app`, `workflow`, `agent`, and `toolset`
+also support SpEL. A value whose first non-whitespace character is `#` is evaluated
+against the method invocation; any other value is treated as a literal — so existing
+literal configurations (e.g. `workspace = "production"`) keep working unchanged.
+
+`#result` is **not** available on subject fields because they are resolved before
+the guarded method runs (they go into the reservation request).
+
+```java
+@Cycles(value = "#tokens * 10", workspace = "#workspaceId")
+public Response runRequest(int tokens, String workspaceId) { ... }
+
+// Nested property
+@Cycles(value = "#req.tokens", workspace = "#req.workspaceId")
+public Response runRequest(Request req) { ... }
+```
+
+If a SpEL expression evaluates to `null` (e.g. `workspace = "#req?.workspaceId"`
+with a null property), the resolver falls through to the configured default and
+finally to a `CyclesFieldResolver` bean, just as if the annotation value were blank.
 
 ## Accessing Caps in Your Method
 

--- a/cycles-client-java-spring/pom.xml
+++ b/cycles-client-java-spring/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.runcycles</groupId>
     <artifactId>cycles-client-java-spring</artifactId>
-    <version>0.2.0</version>
+    <version>0.2.1</version>
     <packaging>jar</packaging>
 
     <name>Cycles Client Java Spring</name>

--- a/cycles-client-java-spring/src/main/java/io/runcycles/client/java/spring/annotation/Cycles.java
+++ b/cycles-client-java-spring/src/main/java/io/runcycles/client/java/spring/annotation/Cycles.java
@@ -56,36 +56,48 @@ public @interface Cycles {
 
     /**
      * Subject field: the tenant identifier. Falls back to config or resolver if blank.
+     * Supports SpEL: a value whose first non-whitespace character is {@code #}
+     * is evaluated against the method invocation (e.g. {@code tenant = "#tenantId"}).
      *
      * @return the tenant identifier, or empty string if unset
      */
     String tenant() default "";
     /**
      * Subject field: the workspace identifier. Falls back to config or resolver if blank.
+     * Supports SpEL: a value whose first non-whitespace character is {@code #}
+     * is evaluated against the method invocation (e.g. {@code workspace = "#workspaceId"}).
      *
      * @return the workspace identifier, or empty string if unset
      */
     String workspace() default "";
     /**
      * Subject field: the application identifier. Falls back to config or resolver if blank.
+     * Supports SpEL: a value whose first non-whitespace character is {@code #}
+     * is evaluated against the method invocation.
      *
      * @return the application identifier, or empty string if unset
      */
     String app() default "";
     /**
      * Subject field: the workflow identifier. Falls back to config or resolver if blank.
+     * Supports SpEL: a value whose first non-whitespace character is {@code #}
+     * is evaluated against the method invocation.
      *
      * @return the workflow identifier, or empty string if unset
      */
     String workflow() default "";
     /**
      * Subject field: the agent identifier. Falls back to config or resolver if blank.
+     * Supports SpEL: a value whose first non-whitespace character is {@code #}
+     * is evaluated against the method invocation.
      *
      * @return the agent identifier, or empty string if unset
      */
     String agent() default "";
     /**
      * Subject field: the toolset identifier. Falls back to config or resolver if blank.
+     * Supports SpEL: a value whose first non-whitespace character is {@code #}
+     * is evaluated against the method invocation.
      *
      * @return the toolset identifier, or empty string if unset
      */

--- a/cycles-client-java-spring/src/main/java/io/runcycles/client/java/spring/autoconfigure/CyclesAutoConfiguration.java
+++ b/cycles-client-java-spring/src/main/java/io/runcycles/client/java/spring/autoconfigure/CyclesAutoConfiguration.java
@@ -114,14 +114,16 @@ public class CyclesAutoConfiguration {
      * Registers the request payload builder service.
      *
      * @param resolutionService the value resolution service
+     * @param evaluator         the SpEL expression evaluator
      * @return the request builder service
      */
     @Bean
     @ConditionalOnMissingBean
     public CyclesRequestBuilderService cyclesRequestBuilderService(
-            CyclesValueResolutionService resolutionService
+            CyclesValueResolutionService resolutionService,
+            CyclesExpressionEvaluator evaluator
     ) {
-        return new CyclesRequestBuilderService(resolutionService);
+        return new CyclesRequestBuilderService(resolutionService, evaluator);
     }
 
     /**
@@ -175,7 +177,7 @@ public class CyclesAutoConfiguration {
      */
     @Bean
     @ConditionalOnMissingBean
-    public CyclesSelfInvocationDetector cyclesSelfInvocationDetector() {
+    public static CyclesSelfInvocationDetector cyclesSelfInvocationDetector() {
         return new CyclesSelfInvocationDetector();
     }
 }

--- a/cycles-client-java-spring/src/main/java/io/runcycles/client/java/spring/context/CyclesLifecycleService.java
+++ b/cycles-client-java-spring/src/main/java/io/runcycles/client/java/spring/context/CyclesLifecycleService.java
@@ -88,7 +88,7 @@ public class CyclesLifecycleService {
 
         // Create reservation
         Map<String, Object> createBody = requestBuilderService.buildReservation(
-                cycles, estimate, actionKind, actionName, null);
+                cycles, estimate, actionKind, actionName, null, method, args, target);
         LOG.debug("Creating reservation: createBody={}", createBody);
 
         long resT1 = System.currentTimeMillis();

--- a/cycles-client-java-spring/src/main/java/io/runcycles/client/java/spring/context/CyclesRequestBuilderService.java
+++ b/cycles-client-java-spring/src/main/java/io/runcycles/client/java/spring/context/CyclesRequestBuilderService.java
@@ -1,12 +1,14 @@
 package io.runcycles.client.java.spring.context;
 
 import io.runcycles.client.java.spring.annotation.Cycles;
+import io.runcycles.client.java.spring.evaluation.CyclesExpressionEvaluator;
 import io.runcycles.client.java.spring.evaluation.CyclesValueResolutionService;
 import io.runcycles.client.java.spring.model.CyclesMetrics;
 import io.runcycles.client.java.spring.model.CyclesProtocolException;
 import io.runcycles.client.java.spring.util.Constants;
 import io.runcycles.client.java.spring.util.ValidationUtils;
 
+import java.lang.reflect.Method;
 import java.util.*;
 
 /**
@@ -35,14 +37,27 @@ public class CyclesRequestBuilderService {
     private static final int MAX_ACTION_NAME_LENGTH = 256;
 
     private final CyclesValueResolutionService cyclesValueResolutionService;
+    private final CyclesExpressionEvaluator expressionEvaluator;
+
+    /**
+     * Creates a new request builder service with a default expression evaluator.
+     *
+     * @param cyclesValueResolutionService the value resolution service for subject fields
+     */
+    public CyclesRequestBuilderService(CyclesValueResolutionService cyclesValueResolutionService) {
+        this(cyclesValueResolutionService, new CyclesExpressionEvaluator());
+    }
 
     /**
      * Creates a new request builder service.
      *
      * @param cyclesValueResolutionService the value resolution service for subject fields
+     * @param expressionEvaluator          the SpEL evaluator used to resolve subject-field expressions
      */
-    public CyclesRequestBuilderService(CyclesValueResolutionService cyclesValueResolutionService) {
+    public CyclesRequestBuilderService(CyclesValueResolutionService cyclesValueResolutionService,
+                                       CyclesExpressionEvaluator expressionEvaluator) {
         this.cyclesValueResolutionService = cyclesValueResolutionService;
+        this.expressionEvaluator = expressionEvaluator;
     }
 
     /**
@@ -59,9 +74,34 @@ public class CyclesRequestBuilderService {
     public Map<String, Object> buildReservation(Cycles cycles, long estimatedAmount,
                                                  String actionKind, String actionName,
                                                  Map<String, Object> metadata) {
+        return buildReservation(cycles, estimatedAmount, actionKind, actionName, metadata, null, null, null);
+    }
+
+    /**
+     * Builds the request body for creating a new reservation, evaluating SpEL expressions
+     * on subject-field annotation attributes against the supplied method invocation.
+     *
+     * <p>Subject-field values starting with {@code #} (e.g. {@code workspace = "#workspaceId"})
+     * are resolved against the method's parameters; literal values are passed through unchanged.
+     *
+     * @param cycles          the annotation providing subject, action, and policy configuration
+     * @param estimatedAmount the estimated usage amount (must be &ge; 0)
+     * @param actionKind      the action category (e.g. class name)
+     * @param actionName      the action identifier (e.g. method name)
+     * @param metadata        optional metadata to include, or {@code null}
+     * @param method          the annotated method, or {@code null} to skip SpEL evaluation
+     * @param args            the method arguments, or {@code null} when {@code method} is {@code null}
+     * @param target          the target bean instance, or {@code null} when {@code method} is {@code null}
+     * @return a mutable map representing the JSON request body
+     * @throws CyclesProtocolException if validation fails
+     */
+    public Map<String, Object> buildReservation(Cycles cycles, long estimatedAmount,
+                                                 String actionKind, String actionName,
+                                                 Map<String, Object> metadata,
+                                                 Method method, Object[] args, Object target) {
         Objects.requireNonNull(cycles, "Cycles annotation must not be null");
 
-        Map<String, String> resolvedFields = resolveSubjectFields(cycles);
+        Map<String, String> resolvedFields = resolveSubjectFields(cycles, method, args, target);
         validateMandatory(resolvedFields, actionKind, actionName, estimatedAmount, cycles.unit());
 
         Map<String, Object> subject = buildSubject(resolvedFields, cycles.dimensions());
@@ -181,7 +221,7 @@ public class CyclesRequestBuilderService {
                                               Map<String, Object> metadata) {
         Objects.requireNonNull(cycles, "Cycles annotation must not be null");
 
-        Map<String, String> resolvedFields = resolveSubjectFields(cycles);
+        Map<String, String> resolvedFields = resolveSubjectFields(cycles, null, null, null);
         validateMandatory(resolvedFields, actionKind, actionName, estimatedAmount, cycles.unit());
 
         Map<String, Object> subject = buildSubject(resolvedFields, cycles.dimensions());
@@ -220,7 +260,7 @@ public class CyclesRequestBuilderService {
                                            Map<String, Object> metadata) {
         Objects.requireNonNull(cycles, "Cycles annotation must not be null");
 
-        Map<String, String> resolvedFields = resolveSubjectFields(cycles);
+        Map<String, String> resolvedFields = resolveSubjectFields(cycles, null, null, null);
         validateMandatory(resolvedFields, actionKind, actionName, actualAmount, cycles.unit());
 
         Map<String, Object> subject = buildSubject(resolvedFields, cycles.dimensions());
@@ -253,15 +293,21 @@ public class CyclesRequestBuilderService {
     // -------------------------
     // Subject
     // -------------------------
-    private Map<String, String> resolveSubjectFields(Cycles c) {
+    private Map<String, String> resolveSubjectFields(Cycles c, Method method, Object[] args, Object target) {
         Map<String, String> resolved = new HashMap<>();
-        resolved.put(Constants.TENANT, cyclesValueResolutionService.resolve(Constants.TENANT, c.tenant()));
-        resolved.put(Constants.WORKSPACE, cyclesValueResolutionService.resolve(Constants.WORKSPACE, c.workspace()));
-        resolved.put(Constants.APP, cyclesValueResolutionService.resolve(Constants.APP, c.app()));
-        resolved.put(Constants.WORKFLOW, cyclesValueResolutionService.resolve(Constants.WORKFLOW, c.workflow()));
-        resolved.put(Constants.AGENT, cyclesValueResolutionService.resolve(Constants.AGENT, c.agent()));
-        resolved.put(Constants.TOOLSET, cyclesValueResolutionService.resolve(Constants.TOOLSET, c.toolset()));
+        resolved.put(Constants.TENANT, resolveSubjectField(Constants.TENANT, c.tenant(), method, args, target));
+        resolved.put(Constants.WORKSPACE, resolveSubjectField(Constants.WORKSPACE, c.workspace(), method, args, target));
+        resolved.put(Constants.APP, resolveSubjectField(Constants.APP, c.app(), method, args, target));
+        resolved.put(Constants.WORKFLOW, resolveSubjectField(Constants.WORKFLOW, c.workflow(), method, args, target));
+        resolved.put(Constants.AGENT, resolveSubjectField(Constants.AGENT, c.agent(), method, args, target));
+        resolved.put(Constants.TOOLSET, resolveSubjectField(Constants.TOOLSET, c.toolset(), method, args, target));
         return resolved;
+    }
+
+    private String resolveSubjectField(String fieldName, String annotationValue,
+                                       Method method, Object[] args, Object target) {
+        String evaluated = expressionEvaluator.evaluateString(annotationValue, method, args, target);
+        return cyclesValueResolutionService.resolve(fieldName, evaluated);
     }
 
     private Map<String, Object> buildSubject(Map<String, String> resolvedFields, String[] dimensions) {

--- a/cycles-client-java-spring/src/main/java/io/runcycles/client/java/spring/evaluation/CyclesExpressionEvaluator.java
+++ b/cycles-client-java-spring/src/main/java/io/runcycles/client/java/spring/evaluation/CyclesExpressionEvaluator.java
@@ -9,6 +9,8 @@ import org.springframework.expression.*;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 
 import java.lang.reflect.Method;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * Evaluates SpEL expressions used in {@code @Cycles} annotations to compute
@@ -32,6 +34,11 @@ public class CyclesExpressionEvaluator {
     private static final Logger LOG = LoggerFactory.getLogger(CyclesExpressionEvaluator.class);
     private final ExpressionParser parser = new SpelExpressionParser();
     private final ParameterNameDiscoverer discoverer = new DefaultParameterNameDiscoverer();
+    private final ConcurrentMap<String, Expression> expressionCache = new ConcurrentHashMap<>();
+
+    private Expression parseCached(String expression) {
+        return expressionCache.computeIfAbsent(expression, parser::parseExpression);
+    }
 
     /**
      * Evaluates a SpEL expression to a non-negative {@code long} value.
@@ -50,7 +57,7 @@ public class CyclesExpressionEvaluator {
                          Object result,
                          Object target) {
         LOG.debug("Evaluating expression: expression={}, method={}, args={}, result={}, target={}", expression, method, args, result, target);
-        Expression exp = parser.parseExpression(expression);
+        Expression exp = parseCached(expression);
 
         MethodBasedEvaluationContext context =
                 new MethodBasedEvaluationContext(
@@ -83,5 +90,42 @@ public class CyclesExpressionEvaluator {
         }
 
         return longValue;
+    }
+
+    /**
+     * Resolves a string-valued attribute that may contain a SpEL expression.
+     *
+     * <p>If {@code value} starts with {@code #} (after leading whitespace), it is parsed
+     * and evaluated as SpEL against a {@link MethodBasedEvaluationContext} built from the
+     * given method invocation. Otherwise the value is returned verbatim — any literal that
+     * does not begin with {@code #} bypasses the parser entirely so existing literal
+     * configurations remain unaffected.
+     *
+     * <p>The evaluation context exposes the same {@code #args} and {@code #target}
+     * variables as {@link #evaluate}, plus all named method parameters. {@code #result}
+     * is intentionally not exposed: subject fields are evaluated before the guarded
+     * method runs.
+     *
+     * @param value  the raw annotation attribute, possibly a SpEL expression
+     * @param method the annotated method (for parameter name discovery); if {@code null},
+     *               {@code value} is returned as-is
+     * @param args   the method invocation arguments
+     * @param target the bean instance on which the method was invoked
+     * @return the resolved string, or {@code null} if the expression evaluates to {@code null}
+     */
+    public String evaluateString(String value, Method method, Object[] args, Object target) {
+        if (value == null || method == null) {
+            return value;
+        }
+        String trimmed = value.stripLeading();
+        if (trimmed.isEmpty() || !trimmed.startsWith("#")) {
+            return value;
+        }
+        Expression exp = parseCached(value);
+        MethodBasedEvaluationContext ctx = new MethodBasedEvaluationContext(target, method, args, discoverer);
+        ctx.setVariable("args", args);
+        ctx.setVariable("target", target);
+        Object result = exp.getValue(ctx);
+        return result == null ? null : result.toString();
     }
 }

--- a/cycles-client-java-spring/src/main/java/io/runcycles/client/java/spring/model/ErrorCode.java
+++ b/cycles-client-java-spring/src/main/java/io/runcycles/client/java/spring/model/ErrorCode.java
@@ -40,6 +40,14 @@ public enum ErrorCode {
     /** An error code not recognized by this client version. */
     UNKNOWN;
 
+    /**
+     * Parses an error-code name into an {@link ErrorCode}, falling back to {@link #UNKNOWN}
+     * when the value is not recognized by this client version.
+     *
+     * @param value the error-code name (e.g. {@code "BUDGET_EXCEEDED"})
+     * @return the matching enum constant, {@link #UNKNOWN} for unrecognized values, or
+     *         {@code null} when {@code value} is {@code null}
+     */
     public static ErrorCode fromString(String value) {
         if (value == null) return null;
         try {
@@ -49,6 +57,12 @@ public enum ErrorCode {
         }
     }
 
+    /**
+     * Indicates whether this error code represents a transient condition for which
+     * a retry may succeed.
+     *
+     * @return {@code true} for {@link #INTERNAL_ERROR} and {@link #UNKNOWN}; {@code false} otherwise
+     */
     public boolean isRetryable() {
         return this == INTERNAL_ERROR || this == UNKNOWN;
     }

--- a/cycles-client-java-spring/src/main/java/io/runcycles/client/java/spring/model/EventResult.java
+++ b/cycles-client-java-spring/src/main/java/io/runcycles/client/java/spring/model/EventResult.java
@@ -21,6 +21,12 @@ public class EventResult {
         this.balances = balances;
     }
 
+    /**
+     * Deserializes the {@code POST /v1/events} response body.
+     *
+     * @param map the parsed JSON body, or {@code null}
+     * @return the typed result, or {@code null} when {@code map} is {@code null}
+     */
     @SuppressWarnings("unchecked")
     public static EventResult fromMap(Map<String, Object> map) {
         if (map == null) return null;
@@ -32,9 +38,32 @@ public class EventResult {
         );
     }
 
+    /**
+     * Returns the server-reported event status (currently always {@code APPLIED}).
+     *
+     * @return the event status
+     */
     public EventStatus getStatus() { return status; }
+
+    /**
+     * Returns the server-assigned event identifier.
+     *
+     * @return the event id, or {@code null} if absent
+     */
     public String getEventId() { return eventId; }
+
+    /**
+     * Returns the amount charged for this event.
+     *
+     * @return the charged amount, or {@code null} if absent
+     */
     public Amount getCharged() { return charged; }
+
+    /**
+     * Returns the post-event balances for the affected scopes.
+     *
+     * @return the balances, or {@code null} if not returned
+     */
     public List<Balance> getBalances() { return balances; }
 
     @Override

--- a/cycles-client-java-spring/src/test/java/io/runcycles/client/java/spring/context/CyclesLifecycleServiceCoverageTest.java
+++ b/cycles-client-java-spring/src/test/java/io/runcycles/client/java/spring/context/CyclesLifecycleServiceCoverageTest.java
@@ -106,7 +106,7 @@ class CyclesLifecycleServiceCoverageTest {
             Method method = dummyMethod();
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             // Return a response with null body which will make ReservationResult.fromMap return null
             when(client.createReservation(any(Object.class)))
@@ -133,7 +133,7 @@ class CyclesLifecycleServiceCoverageTest {
             Method method = dummyMethod();
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
 
             Map<String, Object> body = new HashMap<>();
@@ -164,7 +164,7 @@ class CyclesLifecycleServiceCoverageTest {
             Method method = dummyMethod();
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
 
             Map<String, Object> body = new HashMap<>();
@@ -251,7 +251,7 @@ class CyclesLifecycleServiceCoverageTest {
             when(cycles.useEstimateIfActualNotProvided()).thenReturn(false);
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, allowResponse("r1")));
@@ -281,7 +281,7 @@ class CyclesLifecycleServiceCoverageTest {
             Method method = dummyMethod();
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, allowResponse("res-exp")));
@@ -313,7 +313,7 @@ class CyclesLifecycleServiceCoverageTest {
             Method method = dummyMethod();
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, allowResponse("res-unk")));
@@ -346,7 +346,7 @@ class CyclesLifecycleServiceCoverageTest {
             Method method = dummyMethod();
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
 
             // Error body without proper error response structure
@@ -375,7 +375,7 @@ class CyclesLifecycleServiceCoverageTest {
             Method method = dummyMethod();
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
 
             Map<String, Object> body = new HashMap<>();
@@ -404,7 +404,7 @@ class CyclesLifecycleServiceCoverageTest {
             Method method = dummyMethod();
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, allowResponse("res-no-ttl")));
@@ -435,7 +435,7 @@ class CyclesLifecycleServiceCoverageTest {
             Method method = dummyMethod();
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, allowResponse("res-rel-fail")));
@@ -457,7 +457,7 @@ class CyclesLifecycleServiceCoverageTest {
             Method method = dummyMethod();
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, allowResponse("res-rel-ex")));
@@ -488,7 +488,7 @@ class CyclesLifecycleServiceCoverageTest {
             Method method = dummyMethod();
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
 
             Map<String, Object> body = new HashMap<>();
@@ -518,7 +518,7 @@ class CyclesLifecycleServiceCoverageTest {
             Method method = dummyMethod();
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
 
             Map<String, Object> body = new HashMap<>();
@@ -548,7 +548,7 @@ class CyclesLifecycleServiceCoverageTest {
             Method method = dummyMethod();
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, allowResponse("res-met")));

--- a/cycles-client-java-spring/src/test/java/io/runcycles/client/java/spring/context/CyclesLifecycleServiceTest.java
+++ b/cycles-client-java-spring/src/test/java/io/runcycles/client/java/spring/context/CyclesLifecycleServiceTest.java
@@ -171,7 +171,7 @@ class CyclesLifecycleServiceTest {
             Object target = CyclesLifecycleServiceTest.this;
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, allowResponse("res-ctx")));
@@ -211,7 +211,7 @@ class CyclesLifecycleServiceTest {
                     .thenReturn(1000L);
             when(evaluator.evaluate(eq("#result.length()"), eq(method), eq(args), eq("hello"), eq(target)))
                     .thenReturn(5L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, allowResponse("res-actual")));
@@ -246,7 +246,7 @@ class CyclesLifecycleServiceTest {
             Object target = CyclesLifecycleServiceTest.this;
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, denyResponse()));
@@ -282,7 +282,7 @@ class CyclesLifecycleServiceTest {
             Object target = CyclesLifecycleServiceTest.this;
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, allowWithCapsResponse("res-caps")));
@@ -323,7 +323,7 @@ class CyclesLifecycleServiceTest {
             Object target = CyclesLifecycleServiceTest.this;
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, allowResponse("res-dry")));
@@ -350,7 +350,7 @@ class CyclesLifecycleServiceTest {
             Object target = CyclesLifecycleServiceTest.this;
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, denyResponse()));
@@ -381,7 +381,7 @@ class CyclesLifecycleServiceTest {
             Object target = CyclesLifecycleServiceTest.this;
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
 
             Map<String, Object> errorBody = Map.of(
@@ -418,7 +418,7 @@ class CyclesLifecycleServiceTest {
             Object target = CyclesLifecycleServiceTest.this;
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, allowResponse("res-fail")));
@@ -458,7 +458,7 @@ class CyclesLifecycleServiceTest {
             Object target = CyclesLifecycleServiceTest.this;
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, allowResponse("res-retry")));
@@ -485,7 +485,7 @@ class CyclesLifecycleServiceTest {
             Object target = CyclesLifecycleServiceTest.this;
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, allowResponse("res-5xx")));
@@ -513,7 +513,7 @@ class CyclesLifecycleServiceTest {
             Object target = CyclesLifecycleServiceTest.this;
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, allowResponse("res-fin")));
@@ -542,7 +542,7 @@ class CyclesLifecycleServiceTest {
             Object target = CyclesLifecycleServiceTest.this;
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, allowResponse("res-idem")));
@@ -571,7 +571,7 @@ class CyclesLifecycleServiceTest {
             Object target = CyclesLifecycleServiceTest.this;
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, allowResponse("res-4xx")));
@@ -602,7 +602,7 @@ class CyclesLifecycleServiceTest {
             Object target = CyclesLifecycleServiceTest.this;
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, allowResponse("res-exc")));
@@ -692,7 +692,7 @@ class CyclesLifecycleServiceTest {
             Object target = CyclesLifecycleServiceTest.this;
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, allowResponse("res-noactual")));
@@ -726,7 +726,7 @@ class CyclesLifecycleServiceTest {
             Object target = CyclesLifecycleServiceTest.this;
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
 
             Map<String, Object> responseWithoutId = new HashMap<>();
@@ -763,7 +763,7 @@ class CyclesLifecycleServiceTest {
             Object target = CyclesLifecycleServiceTest.this;
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, allowResponse("res-metrics")));
@@ -812,7 +812,7 @@ class CyclesLifecycleServiceTest {
             Object target = CyclesLifecycleServiceTest.this;
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, allowResponse("res-hb")));
@@ -841,7 +841,7 @@ class CyclesLifecycleServiceTest {
             Object target = CyclesLifecycleServiceTest.this;
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, allowResponse("res-hb-min")));
@@ -869,7 +869,7 @@ class CyclesLifecycleServiceTest {
             Object target = CyclesLifecycleServiceTest.this;
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
 
             // Response without expires_at_ms
@@ -904,7 +904,7 @@ class CyclesLifecycleServiceTest {
             Object target = CyclesLifecycleServiceTest.this;
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, allowResponse("res-zero-ttl")));
@@ -936,7 +936,7 @@ class CyclesLifecycleServiceTest {
                     .thenAnswer(inv -> mockFuture);
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, allowResponse("res-cancel")));
@@ -967,7 +967,7 @@ class CyclesLifecycleServiceTest {
                     .thenAnswer(inv -> mockFuture);
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, allowResponse("res-cancel-fail")));
@@ -1006,7 +1006,7 @@ class CyclesLifecycleServiceTest {
             Map<String, Object> extendResponseBody = Map.of("status", "ACTIVE", "expires_at_ms", newExpiresAtMs);
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, allowResponse("res-extend")));
@@ -1053,7 +1053,7 @@ class CyclesLifecycleServiceTest {
                     });
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, allowResponse("res-ext-fail")));
@@ -1103,7 +1103,7 @@ class CyclesLifecycleServiceTest {
                     });
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, allowResponse("res-ext-exc")));
@@ -1144,7 +1144,7 @@ class CyclesLifecycleServiceTest {
             Object target = CyclesLifecycleServiceTest.this;
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
 
             // Server returns unrecognized decision string like "THROTTLE"
@@ -1182,7 +1182,7 @@ class CyclesLifecycleServiceTest {
             Object target = CyclesLifecycleServiceTest.this;
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
 
             // Return a 2xx response with null body -> ReservationResult.fromMap(null) returns null
@@ -1215,7 +1215,7 @@ class CyclesLifecycleServiceTest {
             Object target = CyclesLifecycleServiceTest.this;
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, allowResponse("res-relfail")));
@@ -1245,7 +1245,7 @@ class CyclesLifecycleServiceTest {
             Object target = CyclesLifecycleServiceTest.this;
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, allowResponse("res-relexc")));
@@ -1284,7 +1284,7 @@ class CyclesLifecycleServiceTest {
             Object target = CyclesLifecycleServiceTest.this;
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, allowResponse("res-expired")));
@@ -1322,7 +1322,7 @@ class CyclesLifecycleServiceTest {
             Object target = CyclesLifecycleServiceTest.this;
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
             when(client.createReservation(any(Object.class)))
                     .thenReturn(CyclesResponse.success(200, allowResponse("res-weird")));
@@ -1362,7 +1362,7 @@ class CyclesLifecycleServiceTest {
             Object target = CyclesLifecycleServiceTest.this;
 
             when(evaluator.evaluate(anyString(), any(), any(), any(), any())).thenReturn(1000L);
-            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any()))
+            when(requestBuilderService.buildReservation(any(), anyLong(), anyString(), anyString(), any(), any(), any(), any()))
                     .thenReturn(Map.of("idempotency_key", "idem-1"));
 
             // Error response body without structured error fields (no "error"/"message"/"request_id")

--- a/cycles-client-java-spring/src/test/java/io/runcycles/client/java/spring/context/CyclesRequestBuilderServiceTest.java
+++ b/cycles-client-java-spring/src/test/java/io/runcycles/client/java/spring/context/CyclesRequestBuilderServiceTest.java
@@ -531,4 +531,67 @@ class CyclesRequestBuilderServiceTest {
                     .hasMessageContaining("tenant");
         }
     }
+
+    // ========================================================================
+    // buildReservation — SpEL on subject fields
+    // ========================================================================
+
+    @Nested
+    @DisplayName("buildReservation — SpEL on subject fields")
+    class BuildReservationSpel {
+
+        public static class Caller {
+            public String run(String workspaceId) { return "ok"; }
+        }
+
+        @Test
+        void shouldEvaluateSpelOnWorkspace() throws Exception {
+            Cycles cycles = mockCycles("test-tenant", "TOKENS", 60000, -1, "ALLOW_IF_AVAILABLE", false);
+            when(cycles.workspace()).thenReturn("#workspaceId");
+            // resolver is a pass-through for whatever evaluateString produced
+            when(resolver.resolve("workspace", "ws-from-spel")).thenReturn("ws-from-spel");
+
+            java.lang.reflect.Method method = Caller.class.getMethod("run", String.class);
+            Map<String, Object> body = service.buildReservation(
+                    cycles, 1000, "llm.completion", "gpt-4", null,
+                    method, new Object[]{"ws-from-spel"}, new Caller());
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> subject = (Map<String, Object>) body.get("subject");
+            assertThat(subject.get("workspace")).isEqualTo("ws-from-spel");
+        }
+
+        @Test
+        void shouldLeaveLiteralWorkspaceUnchanged() throws Exception {
+            Cycles cycles = mockCycles("test-tenant", "TOKENS", 60000, -1, "ALLOW_IF_AVAILABLE", false);
+            when(cycles.workspace()).thenReturn("production");
+            when(resolver.resolve("workspace", "production")).thenReturn("production");
+
+            java.lang.reflect.Method method = Caller.class.getMethod("run", String.class);
+            Map<String, Object> body = service.buildReservation(
+                    cycles, 1000, "llm.completion", "gpt-4", null,
+                    method, new Object[]{"ignored"}, new Caller());
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> subject = (Map<String, Object>) body.get("subject");
+            assertThat(subject.get("workspace")).isEqualTo("production");
+        }
+
+        @Test
+        void shouldFallBackToResolverWhenSpelEvaluatesToNull() throws Exception {
+            Cycles cycles = mockCycles("test-tenant", "TOKENS", 60000, -1, "ALLOW_IF_AVAILABLE", false);
+            when(cycles.workspace()).thenReturn("#workspaceId");
+            // SpEL evaluates to null; resolver chain should kick in and produce a fallback.
+            when(resolver.resolve("workspace", null)).thenReturn("from-resolver");
+
+            java.lang.reflect.Method method = Caller.class.getMethod("run", String.class);
+            Map<String, Object> body = service.buildReservation(
+                    cycles, 1000, "llm.completion", "gpt-4", null,
+                    method, new Object[]{null}, new Caller());
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> subject = (Map<String, Object>) body.get("subject");
+            assertThat(subject.get("workspace")).isEqualTo("from-resolver");
+        }
+    }
 }

--- a/cycles-client-java-spring/src/test/java/io/runcycles/client/java/spring/evaluation/CyclesExpressionEvaluatorTest.java
+++ b/cycles-client-java-spring/src/test/java/io/runcycles/client/java/spring/evaluation/CyclesExpressionEvaluatorTest.java
@@ -24,6 +24,13 @@ class CyclesExpressionEvaluatorTest {
     public static class SampleService {
         public String process(int tokens, String model) { return "done"; }
         public int compute(int a, int b) { return a + b; }
+        public String workspaced(String workspaceId, Request req) { return "ok"; }
+    }
+
+    public static class Request {
+        private final String workspaceId;
+        public Request(String workspaceId) { this.workspaceId = workspaceId; }
+        public String getWorkspaceId() { return workspaceId; }
     }
 
     private Method processMethod() throws NoSuchMethodException {
@@ -32,6 +39,10 @@ class CyclesExpressionEvaluatorTest {
 
     private Method computeMethod() throws NoSuchMethodException {
         return SampleService.class.getMethod("compute", int.class, int.class);
+    }
+
+    private Method workspacedMethod() throws NoSuchMethodException {
+        return SampleService.class.getMethod("workspaced", String.class, Request.class);
     }
 
     // ========================================================================
@@ -198,6 +209,144 @@ class CyclesExpressionEvaluatorTest {
             long result = evaluator.evaluate("#tokens * 0", processMethod(),
                     new Object[]{100, "gpt-4"}, null, new SampleService());
             assertThat(result).isEqualTo(0L);
+        }
+    }
+
+    // ========================================================================
+    // evaluateString — subject-field SpEL resolution
+    // ========================================================================
+
+    @Nested
+    @DisplayName("evaluateString")
+    class EvaluateString {
+
+        @Test
+        void shouldReturnLiteralUnchanged() throws Exception {
+            String result = evaluator.evaluateString("production", processMethod(),
+                    new Object[]{100, "gpt-4"}, new SampleService());
+            assertThat(result).isEqualTo("production");
+        }
+
+        @Test
+        void shouldReturnLiteralWithEmbeddedHashUnchanged() throws Exception {
+            // Leading char is not '#', so this stays a literal even though it contains '#'.
+            String result = evaluator.evaluateString("ws#prod", processMethod(),
+                    new Object[]{100, "gpt-4"}, new SampleService());
+            assertThat(result).isEqualTo("ws#prod");
+        }
+
+        @Test
+        void shouldReturnNullValueUnchanged() throws Exception {
+            String result = evaluator.evaluateString(null, processMethod(),
+                    new Object[]{100, "gpt-4"}, new SampleService());
+            assertThat(result).isNull();
+        }
+
+        @Test
+        void shouldReturnEmptyStringUnchanged() throws Exception {
+            String result = evaluator.evaluateString("", processMethod(),
+                    new Object[]{100, "gpt-4"}, new SampleService());
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void shouldReturnBlankStringUnchanged() throws Exception {
+            String result = evaluator.evaluateString("   ", processMethod(),
+                    new Object[]{100, "gpt-4"}, new SampleService());
+            assertThat(result).isEqualTo("   ");
+        }
+
+        @Test
+        void shouldReturnValueWhenMethodNull() {
+            String result = evaluator.evaluateString("#workspaceId", null, null, null);
+            assertThat(result).isEqualTo("#workspaceId");
+        }
+
+        @Test
+        void shouldResolveSimpleParameterReference() throws Exception {
+            String result = evaluator.evaluateString("#workspaceId", workspacedMethod(),
+                    new Object[]{"ws-42", null}, new SampleService());
+            assertThat(result).isEqualTo("ws-42");
+        }
+
+        @Test
+        void shouldResolveNestedPropertyReference() throws Exception {
+            String result = evaluator.evaluateString("#req.workspaceId", workspacedMethod(),
+                    new Object[]{null, new Request("ws-99")}, new SampleService());
+            assertThat(result).isEqualTo("ws-99");
+        }
+
+        @Test
+        void shouldReturnNullForSafeNavOnNull() throws Exception {
+            String result = evaluator.evaluateString("#req?.workspaceId", workspacedMethod(),
+                    new Object[]{null, null}, new SampleService());
+            assertThat(result).isNull();
+        }
+
+        @Test
+        void shouldStringifyNonStringResult() throws Exception {
+            // #args[0] is an int — SpEL returns Integer; toString applied.
+            String result = evaluator.evaluateString("#tokens", processMethod(),
+                    new Object[]{42, "gpt-4"}, new SampleService());
+            assertThat(result).isEqualTo("42");
+        }
+
+        @Test
+        void shouldHonorLeadingWhitespaceBeforeHash() throws Exception {
+            String result = evaluator.evaluateString("  #workspaceId", workspacedMethod(),
+                    new Object[]{"ws-77", null}, new SampleService());
+            assertThat(result).isEqualTo("ws-77");
+        }
+
+        @Test
+        void shouldReturnNullForUnknownVariableReference() throws Exception {
+            // SpEL resolves an unknown #var to null rather than throwing. evaluateString returns
+            // null so the resolver fallback chain (config → resolver bean) takes over — this is
+            // the documented graceful path for safe-nav expressions like `#req?.workspaceId`.
+            String result = evaluator.evaluateString("#nope", processMethod(),
+                    new Object[]{100, "gpt-4"}, new SampleService());
+            assertThat(result).isNull();
+        }
+
+        @Test
+        void shouldPropagateEvaluationErrorOnInvalidPropertyAccess() throws Exception {
+            // Property access on a non-null value that doesn't have the property fails fast at
+            // AOP entry (SpelEvaluationException) instead of producing a malformed server request.
+            assertThatThrownBy(() -> evaluator.evaluateString("#tokens.noSuchProperty", processMethod(),
+                    new Object[]{100, "gpt-4"}, new SampleService()))
+                    .isInstanceOf(org.springframework.expression.spel.SpelEvaluationException.class);
+        }
+
+        @Test
+        void shouldPropagateParseErrorForMalformedExpression() throws Exception {
+            // Malformed SpEL fails fast at AOP entry (ParseException) instead of being sent to
+            // the server.
+            assertThatThrownBy(() -> evaluator.evaluateString("#((bad", processMethod(),
+                    new Object[]{100, "gpt-4"}, new SampleService()))
+                    .isInstanceOf(org.springframework.expression.ParseException.class);
+        }
+    }
+
+    // ========================================================================
+    // Expression cache
+    // ========================================================================
+
+    @Nested
+    @DisplayName("Expression cache")
+    class ExpressionCache {
+
+        @Test
+        void shouldReturnConsistentResultsAcrossRepeatedEvaluations() throws Exception {
+            // Many repeated evaluations of the same expression should all succeed and produce
+            // identical output, validating that the cached Expression remains usable across calls.
+            for (int i = 0; i < 50; i++) {
+                long est = evaluator.evaluate("#tokens * 10", processMethod(),
+                        new Object[]{100, "gpt-4"}, null, new SampleService());
+                String ws = evaluator.evaluateString("#workspaceId", workspacedMethod(),
+                        new Object[]{"ws-cache", null}, new SampleService());
+                assertThat(est).isEqualTo(1000L);
+                assertThat(ws).isEqualTo("ws-cache");
+            }
         }
     }
 }

--- a/cycles-demo-client-java-spring/pom.xml
+++ b/cycles-demo-client-java-spring/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.example</groupId>
     <artifactId>cycles-demo-client-java-spring</artifactId>
-    <version>0.2.0</version>
+    <version>0.2.1</version>
     <packaging>jar</packaging>
 
     <name>Cycles demo client for JAVA Spring</name>
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>io.runcycles</groupId>
             <artifactId>cycles-client-java-spring</artifactId>
-            <version>0.2.0</version>
+            <version>0.2.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary

Closes #49.

- **Primary fix**: SpEL on `@Cycles` subject-field attributes (`tenant`, `workspace`, `app`, `workflow`, `agent`, `toolset`) now evaluates correctly. Previously `workspace = "#workspaceId"` was sent verbatim and the server returned 400 `INVALID_REQUEST`. New `CyclesExpressionEvaluator.evaluateString` parses values whose first non-whitespace char is `#`; literal values bypass the parser entirely so existing configurations are byte-identical.
- **BeanPostProcessor warning**: `cyclesSelfInvocationDetector()` is now a `static` `@Bean` factory method, eliminating the *"not eligible for getting processed by all BeanPostProcessors"* startup warning.
- **Perf**: parsed `Expression` instances are cached per raw expression string in `CyclesExpressionEvaluator` (mirrors Spring's `CachedExpressionEvaluator` pattern).
- **Docs**: Javadoc on six `@Cycles` subject fields documents the SpEL behavior; README "SpEL Expressions" section gets a "SpEL on subject fields" subsection; `AUDIT.md` and `CHANGELOG.md` updated; missing Javadoc on `ErrorCode`/`EventResult` filled in so `mvn verify` is warning-free.
- **Version**: 0.2.0 → 0.2.1 across both POMs.

## Behavior change

A subject-field SpEL that fails to **parse** (e.g. `#((bad`) or fails to **evaluate against actual values** (e.g. invalid property access) now surfaces at AOP entry as `ParseException` / `SpelEvaluationException` instead of producing a malformed reservation request. References to undefined variables still resolve to `null` and fall through to the config → resolver bean chain — matching `#req?.workspaceId` semantics.

## Test plan

- [x] `mvn verify` on `cycles-client-java-spring` — **432 tests pass**, JaCoCo 95% gate met, no Javadoc warnings
- [x] `mvn verify` on `cycles-demo-client-java-spring` — builds and repackages cleanly
- [x] New unit tests in `CyclesExpressionEvaluatorTest`: 13 cases for `evaluateString` (literal / null / blank / `#var` / nested / safe-nav / non-String / leading-whitespace / unknown-var → null / parse error / eval error) plus an `ExpressionCache` repeated-evaluation test
- [x] New end-to-end tests in `CyclesRequestBuilderServiceTest.BuildReservationSpel`: `@Cycles(workspace = "#workspaceId")` produces resolved value; literal preserved; SpEL → null falls through to resolver
- [x] Existing 36 `CyclesLifecycleServiceTest` / `…CoverageTest` Mockito stubs migrated to the 8-arg `buildReservation` signature
- [ ] Reviewer to spot-check that an existing user upgrading from 0.2.0 with `@Cycles(workspace = "production")` (literal) sees no behavior change