### PR TITLE
docs(readme): front-load search keywords in hook for GitHub discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 [![Coverage](https://img.shields.io/badge/coverage-85%25-brightgreen)](https://github.com/runcycles/cycles-spring-boot-starter/actions)
 
-# Cycles Spring Boot Starter
+# Cycles Spring Boot Starter — AI agent budget governance for Java/Spring
 
-A Spring Boot starter that integrates with the [Cycles Budget Authority](https://github.com/runcycles/cycles-protocol) — a deterministic spend governance protocol for agent runtimes.
+**Drop-in `@Cycles` annotation that enforces budget and action limits on Spring Boot AI agents and LLM-calling services.** Integrates with the [Cycles Protocol](https://github.com/runcycles/cycles-protocol) for runtime authority over agent spend, risk, and tool actions — multi-tenant, concurrency-safe, and Spring-native.
 
-Cycles enforces budget reservations around guarded method executions using a **reserve / execute / commit** lifecycle. If the budget is exceeded, execution is denied before the guarded code runs.
+Reserve budget around guarded method executions using a **reserve / execute / commit** lifecycle. If the budget is exceeded, execution is denied before the guarded code runs. Compatible with Java 21+ and Spring Boot 3.3+.
 
 ## Quick Start
 


### PR DESCRIPTION
## What

Rewrites the H1 + opening of `README.md` so the GitHub search excerpt front-loads Java/Spring + AI agent governance phrases.

**Before** (line 5): `# Cycles Spring Boot Starter`
**After**: `# Cycles Spring Boot Starter — AI agent budget governance for Java/Spring`

The two-paragraph summary now leads with the `@Cycles` annotation surface, names "multi-tenant" and "concurrency-safe", and adds a Java/Spring version-compat line.

## Why

GitHub repo search ranks and excerpts on the top of the README. A Spring Boot dev searching for "Spring Boot AI agent governance", "LLM budget Spring", or "Java agent cost control" would not match the previous opening on those phrases.

## Scope

- 1 file changed: `README.md`
- 5 lines edited (5, 7, 9), no structural changes below line 9
- No removed examples, links, or configuration

Part of an SEO/discoverability pass across the runcycles org. Sibling PRs: cycles-protocol#78, cycles-server#140, cycles-server-admin#157.
