### PR TITLE
ops: add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,59 @@
+# OpenSSF Scorecard — supply-chain security analysis.
+#
+# Runs on push to main, on branch-protection-rule changes, and weekly so the
+# score stays current as the repo evolves. Results are uploaded to GitHub's
+# code-scanning surface (visible in Security tab) and published to the public
+# OpenSSF metric API at api.scorecard.dev so the badge auto-updates.
+#
+# What it scores: branch protection, signed commits, dependency review,
+# pinned dependencies, token permissions, vulnerability disclosure, fuzzing,
+# SAST, and ~14 other supply-chain practices. Scores 0-10.
+#
+# Setup notes:
+# - publish_results: true requires the repo to be public (it is).
+# - id-token: write is required to mint the OIDC token used for publishing.
+# - Workflow MUST live on the default branch for results to publish.
+name: Scorecard supply-chain security
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '0 6 * * 1'  # Monday 06:00 UTC — weekly refresh
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write   # Upload SARIF to code-scanning
+      id-token: write          # Mint OIDC token for publish to api.scorecard.dev
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@aa578102511db1f4524ed59b8cc2bae4f6e88195 # v3.27.6
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Adds [OpenSSF Scorecard](https://github.com/ossf/scorecard) supply-chain security analysis. Same workflow already merged in [runcycles/cycles-server#142](https://github.com/runcycles/cycles-server/pull/142).

## Why this repo
The Maven Central artifact shipped from this repo is a tier-1 supply-chain entry point — every Spring AI / Java integration via Cycles pulls it. Scorecard signals to downstream consumers that supply-chain practices are audited.

## What it scores
~17 practices on a 0–10 scale: branch protection, signed commits, dependency review, pinned dependencies, token permissions, vulnerability disclosure, fuzzing, SAST, dangerous workflow patterns. Full list: https://github.com/ossf/scorecard/blob/main/docs/checks.md

## Runs
- On push to main (immediate first score after merge)
- On \`branch_protection_rule\` changes
- Weekly (Mon 06:00 UTC)

## Where results land
1. Security tab (SARIF upload)
2. Public scorecard at https://scorecard.dev/viewer/?uri=github.com/runcycles/cycles-spring-boot-starter (24h after first run)
3. Auto-updating badge: \`https://api.scorecard.dev/projects/github.com/runcycles/cycles-spring-boot-starter/badge\`

## Notes
- Action SHAs pinned per Scorecard's pinned-dependencies criterion
- \`publish_results: true\` requires public repo (it is)
- Workflow must live on default branch — this PR puts it there

## Test plan
- [ ] Merge → verify workflow runs to green on post-merge push
- [ ] Check Security tab — SARIF visible
- [ ] Check scorecard.dev page after 24h
- [ ] First score ≥6 reasonable; ≥8 strong; <5 means immediate hardening warranted