### PR TITLE
ops: pin all third-party GitHub Action SHAs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,8 +13,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@v3
-
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
       - name: Enable auto-merge for patch updates
         if: steps.meta.outputs.update-type == 'version-update:semver-patch'
         run: gh pr merge --auto --merge "$PR_URL"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,10 +17,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
-
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: temurin
           java-version: '21'
@@ -48,10 +47,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
-
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: temurin
           java-version: '21'


### PR DESCRIPTION
Same SHA-pinning sweep as [runcycles/cycles-server#143](https://github.com/runcycles/cycles-server/pull/143). Addresses the **Pinned-Dependencies** criterion from OpenSSF Scorecard (target 0 → 10).

5 refs pinned across `dependabot-auto-merge.yml` and `publish.yaml`. Dependabot already manages the `github-actions` ecosystem and will keep these SHAs current via auto-PRs.

SHAs resolved 2026-05-02 from each action's repo via `gh api repos/<owner>/<repo>/commits/<ref>`.