### PR TITLE
ops: tighten workflow token permissions (Scorecard PR B)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,14 +2,18 @@ name: Dependabot auto-merge
 
 on: pull_request
 
-permissions:
-  contents: write
-  pull-requests: write
+# Default to read-all at top level; the automerge job below escalates only the
+# narrow scopes it actually needs. Per OpenSSF Scorecard's Token-Permissions
+# criterion: avoid blanket write at the workflow level.
+permissions: read-all
 
 jobs:
   automerge:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]'
+    permissions:
+      contents: write          # required to enable auto-merge
+      pull-requests: write     # required to mark the PR as auto-merge
     steps:
       - name: Fetch Dependabot metadata
         id: meta

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,6 +5,8 @@ on:
   release:
     types: [created]
 
+permissions: read-all
+
 jobs:
   test-release-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Same pattern as [cycles-server#144](https://github.com/runcycles/cycles-server/pull/144). Adds top-level read-all to publish.yaml; rewrites dependabot-auto-merge.yml. Addresses **Token-Permissions** in OpenSSF Scorecard.