### PR TITLE
fix(deps): bump Spring Boot 3.3.13 -> 3.5.3 to clear residual OSV vulns

### DIFF
--- a/cycles-client-java-spring/pom.xml
+++ b/cycles-client-java-spring/pom.xml
@@ -46,7 +46,7 @@
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring.boot.version>3.3.13</spring.boot.version>
+        <spring.boot.version>3.5.3</spring.boot.version>
     </properties>
 
     <dependencies>

--- a/cycles-demo-client-java-spring/pom.xml
+++ b/cycles-demo-client-java-spring/pom.xml
@@ -16,12 +16,12 @@
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <spring.boot.version>3.3.13</spring.boot.version>
+        <spring.boot.version>3.5.3</spring.boot.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.13</version>
+        <version>3.5.3</version>
     </parent>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
Follow-up to [PR #55](https://github.com/runcycles/cycles-spring-boot-starter/pull/55), which bumped 3.3.7 → 3.3.13 and cleared 14 of 42 GHSA findings.

## Investigation of residual 28
Pulled all 28 GHSAs and aggregated by package + minimum fix version:

| Bucket | Count | Status |
|---|---|---|
| Fixable in Spring Boot 3.x line (newer Tomcat 10.1.x / Spring 6.2.x / Netty 4.1.x / Logback / Jackson 2.x patches) | ~16 | ✓ This PR fixes |
| Cross-major fixes (Tomcat 11, Spring 7, Netty 4.2, Jackson 3) | ~9 | ✗ Need Spring Boot 4 (doesn't exist yet) |
| No-fix CVEs OSV is tracking | ~3 | ✗ No upstream fix available |

## Why 3.5.3 (not 3.4.7)
3.5.3 (June 2025) bundles the most recent Tomcat 10.1.x, Spring Framework 6.2.x, Netty 4.1.x, Logback 1.5.x, and Jackson 2.19.x. Going through 3.4.7 first would mean two PRs to clear the same vulns.

## Expected outcome
28 residual → **~12 residual** after this lands. The remaining ~12 are structural to staying in Spring Boot 3.x — accept as informational or dismiss in Security tab with a clear reason (tracked separately).

## Risk
Two minor-version jump (3.3 → 3.5):
- Spring Boot 3.4 renamed some configuration properties (e.g., `management.endpoint.health.probes.add-additional-paths`)
- Removed deprecated APIs from 3.2/3.3
- Spring Boot 3.5 added more deprecations

Most projects upgrade cleanly. CI will catch any issue. If something breaks, fall back to 3.4.7 as intermediate.

## Files changed
- `cycles-client-java-spring/pom.xml:49` (`spring.boot.version` property)
- `cycles-demo-client-java-spring/pom.xml:19` (`spring.boot.version` property)
- `cycles-demo-client-java-spring/pom.xml:24` (`<parent>` declaration)

## Test plan
- [ ] CI passes (Maven build + tests against 3.5.3)
- [ ] After merge, next Scorecard scan shows VulnerabilitiesID count drop from 28 → ~12