### PR TITLE
chore(seo): retarget Maven pom description for category-search discovery (0.2.2)

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -256,3 +256,16 @@ Three low-severity gaps identified (response header capture, typed DTO validatio
 - `CyclesRequestBuilderService` gains a context-aware `buildReservation` overload `(Cycles, long, String, String, Map, Method, Object[], Object)` that the AOP path uses. The existing 5-arg overload delegates with `null` invocation context (literal-only), so programmatic callers (`buildDecision`, `buildEvent`) keep their previous semantics.
 - `CyclesAutoConfiguration#cyclesSelfInvocationDetector` is now `static`, eliminating the Spring startup warning *"Bean ... is not eligible for getting processed by all BeanPostProcessors"* and ensuring the configuration class is properly post-processed.
 - New tests: `CyclesExpressionEvaluatorTest.EvaluateString` (literal/null/blank/`#var`/nested/safe-nav/non-String/leading-whitespace) and `CyclesRequestBuilderServiceTest.BuildReservationSpel` (end-to-end resolution of `@Cycles(workspace = "#workspaceId")` with fallback to resolver on null).
+
+---
+
+## 0.2.2 — Maven Central Metadata Refresh (2026-05-07)
+
+**Files:** `cycles-client-java-spring/pom.xml`. **No code changes.** Wire format, public API, Spring AOP integration, and protocol conformance are identical to 0.2.1.
+
+- **`<description>` rewritten** to lead with the cost / action / audit pillars and explicit AI-agent / Spring AI positioning: *"Spring Boot starter for AI agent runtime control with Cycles. Enforce LLM cost limits, tool call caps, action permissions, and audit trails on Spring AI / Spring Boot agents before execution. Reactive WebFlux client with @Cycles annotation, SpEL-based subject routing, and per-tenant budget enforcement."*
+- **`<name>` updated** to *"Cycles Client Java Spring — AI agent runtime control for Spring Boot"*.
+
+Maven Central uses the pom `<description>` as the primary search/snippet field (no keyword field exists in Maven coordinates), so it's the only SEO lever available for the artifact. The previous one-liner *"Spring-based Java client for the Cycles protocol."* offered no category-search surface.
+
+Driven by package-portfolio SEO diagnostic. Companion fixes for other client packages tracked in their respective repos.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/).
 
+## [0.2.2] - 2026-05-07
+
+Maven Central metadata refresh for category-search discovery. **No code changes** — wire format, public API, and Spring AOP integration are identical to 0.2.1.
+
+### Changed
+
+- `pom.xml` (`cycles-client-java-spring`): rewrote `<description>` to lead with the cost / action / audit pillars and explicit AI-agent / Spring AI positioning. New: *"Spring Boot starter for AI agent runtime control with Cycles. Enforce LLM cost limits, tool call caps, action permissions, and audit trails on Spring AI / Spring Boot agents before execution. Reactive WebFlux client with @Cycles annotation, SpEL-based subject routing, and per-tenant budget enforcement."* Updated `<name>` to *"Cycles Client Java Spring — AI agent runtime control for Spring Boot"*.
+
+Maven Central uses the pom `<description>` as the primary search/snippet field (no keyword field exists in Maven coordinates). The previous one-liner *"Spring-based Java client for the Cycles protocol."* offered no category-search surface.
+
 ## [0.2.1] - 2026-04-27
 
 ### Fixed

--- a/cycles-client-java-spring/pom.xml
+++ b/cycles-client-java-spring/pom.xml
@@ -7,11 +7,11 @@
 
     <groupId>io.runcycles</groupId>
     <artifactId>cycles-client-java-spring</artifactId>
-    <version>0.2.1</version>
+    <version>0.2.2</version>
     <packaging>jar</packaging>
 
-    <name>Cycles Client Java Spring</name>
-    <description>Spring-based Java client for the Cycles protocol.</description>
+    <name>Cycles Client Java Spring — AI agent runtime control for Spring Boot</name>
+    <description>Spring Boot starter for AI agent runtime control with Cycles. Enforce LLM cost limits, tool call caps, action permissions, and audit trails on Spring AI / Spring Boot agents before execution. Reactive WebFlux client with @Cycles annotation, SpEL-based subject routing, and per-tenant budget enforcement.</description>
     <url>https://github.com/runcycles/cycles-spring-boot-starter</url>
 
     <developers>


### PR DESCRIPTION
## Summary
Metadata-only release — no code changes. Bumps **0.2.1 → 0.2.2**. Wire format, public API, Spring AOP integration, and protocol conformance are identical to 0.2.1.

## Why
Package-portfolio SEO diagnostic across runcycles client packages found that the Maven artifact's `<description>` was the **most barren in the portfolio** — *"Spring-based Java client for the Cycles protocol."* — with no AI-agent, cost-control, or audit-trail terms.

Maven Central uses the pom `<description>` as the **primary search/snippet field** (no keyword field exists in Maven coordinates), so the description is the only SEO lever available for the artifact. Without category-search terms in it, the package was effectively invisible to anyone searching Maven Central for AI agent / cost control / audit-trail Java libraries.

## Two changes

### 1. `<description>` rewritten

| | |
|---|---|
| Old | `Spring-based Java client for the Cycles protocol.` |
| New | `Spring Boot starter for AI agent runtime control with Cycles. Enforce LLM cost limits, tool call caps, action permissions, and audit trails on Spring AI / Spring Boot agents before execution. Reactive WebFlux client with @Cycles annotation, SpEL-based subject routing, and per-tenant budget enforcement.` |

### 2. `<name>` updated

| | |
|---|---|
| Old | `Cycles Client Java Spring` |
| New | `Cycles Client Java Spring — AI agent runtime control for Spring Boot` |

The `<name>` is what Maven Central displays as the human-readable artifact name in search results.

### 3. Version bump 0.2.1 → 0.2.2 + CHANGELOG + AUDIT entries.

## When this takes effect
On next Maven Central publish (release workflow). Maven Central reindex typically 1–4 hours; sonatype.com search reindex ~24h.

## Test plan
- [ ] Merge.
- [ ] Tag and release `v0.2.2` → triggers Maven Central publish workflow.
- [ ] Verify on https://central.sonatype.com/artifact/io.runcycles/cycles-client-java-spring that the new description and name show up.
- [ ] Search `mvnrepository.com` for `\"AI agent runtime control\"`, `\"Spring AI cost\"`, `\"agent audit trail Spring\"` in ~24h; the artifact should start surfacing.

## Companion changes
Part of a package-portfolio SEO refresh:
- `runcycles/cycles-openclaw-budget-guard` PR #98 (npm 0.8.4)
- `runcycles/cycles-client-typescript` PR #88 (npm 0.3.1)
- `runcycles/cycles-openai-agents` PR #26 (PyPI 0.2.1)