### PR TITLE
ci(publish): add SNAPSHOT + tag-match guards to publish.yaml

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,6 +32,34 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: GPG_PASSPHRASE
 
+      - name: Verify pom version is not SNAPSHOT
+        working-directory: cycles-client-java-spring
+        # Sonatype Central rejects SNAPSHOT publishes server-side, but we'd rather
+        # fail fast on the runner than wait for the deploy step. Tracked org-wide
+        # at runcycles/.github#61.
+        run: |
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          if [[ "$VERSION" == *SNAPSHOT* ]]; then
+            echo "::error::Cannot publish SNAPSHOT version: $VERSION. Drop -SNAPSHOT in the pom before tagging."
+            exit 1
+          fi
+          echo "pom version: $VERSION"
+
+      - name: Verify pom version matches release tag
+        if: github.event_name == 'release'
+        working-directory: cycles-client-java-spring
+        # Catches the case where someone tags v0.1.1 while the pom still says 0.1.0.
+        # Sonatype would publish the artifact at the pom version, not the tag,
+        # producing a release artifact that doesn't match the git tag.
+        run: |
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          TAG="${GITHUB_REF_NAME#v}"
+          if [[ "$VERSION" != "$TAG" ]]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} does not match pom version ${VERSION}. Bump the pom version to match the tag before re-cutting the release."
+            exit 1
+          fi
+          echo "Tag ${GITHUB_REF_NAME} matches pom version ${VERSION}"
+
       - name: Test release build without publishing
         working-directory: cycles-client-java-spring
         run: mvn -B -Prelease clean verify
@@ -61,6 +89,29 @@ jobs:
           server-password: CENTRAL_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: GPG_PASSPHRASE
+
+      - name: Verify pom version is not SNAPSHOT
+        working-directory: cycles-client-java-spring
+        run: |
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          if [[ "$VERSION" == *SNAPSHOT* ]]; then
+            echo "::error::Cannot publish SNAPSHOT version: $VERSION. Drop -SNAPSHOT in the pom before tagging."
+            exit 1
+          fi
+          echo "pom version: $VERSION"
+
+      - name: Verify pom version matches release tag
+        working-directory: cycles-client-java-spring
+        # Belt + suspenders: also verify in the publish job in case the upstream
+        # test-release-build check is ever bypassed.
+        run: |
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          TAG="${GITHUB_REF_NAME#v}"
+          if [[ "$VERSION" != "$TAG" ]]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} does not match pom version ${VERSION}."
+            exit 1
+          fi
+          echo "Publishing version: $VERSION (matches tag ${GITHUB_REF_NAME})"
 
       - name: Publish
         working-directory: cycles-client-java-spring

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -269,3 +269,20 @@ Three low-severity gaps identified (response header capture, typed DTO validatio
 Maven Central uses the pom `<description>` as the primary search/snippet field (no keyword field exists in Maven coordinates), so it's the only SEO lever available for the artifact. The previous one-liner *"Spring-based Java client for the Cycles protocol."* offered no category-search surface.
 
 Driven by package-portfolio SEO diagnostic. Companion fixes for other client packages tracked in their respective repos.
+
+---
+
+## CI: SNAPSHOT-version guard on publish.yaml (2026-05-12)
+
+**Files:** `.github/workflows/publish.yaml`. **No code changes.** Wire format, public API, and protocol conformance unchanged.
+
+Closes `runcycles/.github#61` for this repo. Mirrors the same fix already present in `cycles-spring-ai-starter/.github/workflows/publish.yaml`.
+
+Added two guard steps to both jobs (`test-release-build` and `publish`):
+
+1. **Verify pom version is not SNAPSHOT.** Reads the resolved project version via `mvn help:evaluate -Dexpression=project.version` and fails the workflow if it ends in `-SNAPSHOT`. Sonatype Central rejects SNAPSHOT publishes server-side, but a runner-side fail surfaces the operator error before the deploy phase.
+2. **Verify pom version matches release tag.** Catches the case where someone cuts a release tagged `v0.2.3` while the pom is still on `0.2.2`. Without this check, Maven would publish at the pom version, producing a Central artifact whose Maven coordinate doesn't match the git tag — recoverable but confusing.
+
+The guards run before the build/deploy steps so they fail fast. Workflow shape is otherwise unchanged.
+
+Protocol conformance: No protocol or wire-format changes. CI-only update.


### PR DESCRIPTION
## Summary

Mirrors the same fix already present in [`cycles-spring-ai-starter/.github/workflows/publish.yaml`](https://github.com/runcycles/cycles-spring-ai-starter/blob/main/.github/workflows/publish.yaml) — the reference implementation cited in `runcycles/.github#61`.

Closes `runcycles/.github#61` for this repo.

## Changes

Two new guard steps in both `test-release-build` and `publish` jobs, running before the build/deploy phase so they fail fast:

### `Verify pom version is not SNAPSHOT`
```bash
VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
if [[ "$VERSION" == *SNAPSHOT* ]]; then
  echo "::error::Cannot publish SNAPSHOT version: $VERSION..."
  exit 1
fi
```
Sonatype Central rejects SNAPSHOT publishes server-side anyway, but a runner-side fail surfaces the operator error earlier in the pipeline (without waiting for the Central upload to reject).

### `Verify pom version matches release tag`
Runs on `release` events and catches the case where someone cuts a release tagged `v0.2.3` while the pom is still on `0.2.2`. Without this check, Maven would publish at the pom version, producing a Central artifact whose coordinate doesn't match the git tag.

Both jobs get both guards (belt + suspenders — if a future change ever bypasses the `test-release-build` job, the `publish` job's copy of the guards still catches it).

## Risk

CI-only — no protocol, wire-format, or behavioral change to the published artifact. The guards reject more workflow runs (which is the point) but don't change the output of successful runs.

## Test plan

- [x] `python -m yaml.safe_load` parses `.github/workflows/publish.yaml`
- [ ] Manual smoke: dispatch the workflow against a SNAPSHOT pom on a branch and confirm the guard fails the run at the verify step, not the deploy step
- [ ] Manual smoke: cut a release with mismatched tag/pom and confirm the tag-match guard fails

## Notes

- AUDIT.md updated with a CI-only entry; protocol conformance unchanged.
- Same change shape as `cycles-spring-ai-starter`'s existing guards — no novel pattern, just bringing this repo in line.