### PR TITLE
chore: org-wide hygiene bundle (#60 pin reusable CI to @v1, #62 don't destroy ~/.m2, #63 global-deny hardening)

### DIFF
--- a/.claude/session-start-global-deny.sh
+++ b/.claude/session-start-global-deny.sh
@@ -12,13 +12,18 @@ set -e
 
 GLOBAL_SETTINGS="$HOME/.claude/settings.json"
 
-if ! [ -f "$GLOBAL_SETTINGS" ] || ! grep -q "mcp__github__push_files" "$GLOBAL_SETTINGS" 2>/dev/null; then
-  mkdir -p "$HOME/.claude"
+# The previous version of this block only ran the merge when push_files was
+# missing, which silently left the policy incomplete if push_files happened to
+# exist while one of the other two rules had been removed. The python3 merge
+# is idempotent (skips rules already present), so we now always run it on
+# session start to guarantee all three deny rules are in place.
+# Tracked org-wide at runcycles/.github#63.
+mkdir -p "$HOME/.claude"
 
-  if [ -f "$GLOBAL_SETTINGS" ]; then
-    TMP_SETTINGS=$(mktemp)
-    if command -v python3 &>/dev/null; then
-      python3 -c "
+if [ -f "$GLOBAL_SETTINGS" ]; then
+  TMP_SETTINGS=$(mktemp)
+  if command -v python3 &>/dev/null; then
+    python3 -c "
 import json
 with open('$GLOBAL_SETTINGS') as f:
     settings = json.load(f)
@@ -37,11 +42,11 @@ with open('$TMP_SETTINGS', 'w') as f:
     json.dump(settings, f, indent=2)
     f.write('\n')
 " && mv "$TMP_SETTINGS" "$GLOBAL_SETTINGS"
-    else
-      rm -f "$TMP_SETTINGS"
-    fi
   else
-    cat > "$GLOBAL_SETTINGS" << 'EOF'
+    rm -f "$TMP_SETTINGS"
+  fi
+else
+  cat > "$GLOBAL_SETTINGS" << 'EOF'
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
@@ -53,10 +58,19 @@ with open('$TMP_SETTINGS', 'w') as f:
   }
 }
 EOF
-  fi
 fi
 
 # --- Part 2: Fix git remote URLs to use local proxy ---
+# NOTE: This block intentionally rewrites the `origin` remote on EVERY sibling
+# repo under /home/user/* with a github.com remote, not just this one. Claude
+# Code remote sessions clone multiple repos and all need the local git proxy.
+# To opt out (e.g., when running outside that environment, or when you want
+# unrelated checkouts left alone), set CYCLES_CLAUDE_SKIP_REMOTE_REWRITE=1.
+# Tracked org-wide at runcycles/.github#63.
+if [ -n "$CYCLES_CLAUDE_SKIP_REMOTE_REWRITE" ]; then
+  exit 0
+fi
+
 # Some sessions clone repos via github.com directly, which lacks push credentials.
 # If the local git proxy is running, rewrite remote URLs to use it.
 

--- a/.claude/session-start-maven-proxy.sh
+++ b/.claude/session-start-maven-proxy.sh
@@ -22,9 +22,16 @@ if [ -z "$PROXY_USER" ] || [ -z "$PROXY_PASS" ]; then
   exit 0
 fi
 
-# Create Maven settings.xml with proxy config
+# Create Maven settings.xml with proxy config — defensively skip if a user-
+# managed settings.xml already exists, so we don't wipe pre-existing mirrors,
+# credentials, or alternate proxy configs. Tracked org-wide at runcycles/.github#62.
 mkdir -p ~/.m2
-cat > ~/.m2/settings.xml << XMLEOF
+if [ -f ~/.m2/settings.xml ]; then
+  echo "[cycles] ~/.m2/settings.xml already exists; not overwriting." >&2
+  echo "[cycles] If Maven proxy access fails, merge the <proxies> block from" >&2
+  echo "[cycles] .claude/session-start-maven-proxy.sh into your existing settings.xml." >&2
+else
+  cat > ~/.m2/settings.xml << XMLEOF
 <settings>
   <proxies>
     <proxy>
@@ -48,6 +55,7 @@ cat > ~/.m2/settings.xml << XMLEOF
   </proxies>
 </settings>
 XMLEOF
+fi
 
 # Install mvn-proxy wrapper that fixes JAVA_TOOL_OPTIONS interference
 MVN_BIN=$(which mvn 2>/dev/null || echo "/opt/maven/bin/mvn")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   ci:
-    uses: runcycles/.github/.github/workflows/ci-java.yml@main
+    uses: runcycles/.github/.github/workflows/ci-java.yml@v1
     with:
       pom-file: cycles-client-java-spring/pom.xml
       extra-steps: true


### PR DESCRIPTION
## Summary

First repo in the org-wide propagation of deferred findings from the `cycles-spring-ai-starter` PR review series. Three of the four agreed-deferred issues are addressed here in one bundle. The fourth (#61 SNAPSHOT guard) was already shipped to this repo previously.

## What changed

### [runcycles/.github#60](https://github.com/runcycles/.github/issues/60) — Pin reusable CI workflow to `@v1`

`.github/workflows/ci.yml` now references `runcycles/.github/.github/workflows/ci-java.yml@v1` instead of `@main`. The `v1` tag on `runcycles/.github` already exists (cycles-client-python is using `ci-python.yml@v1` as the precedent), so this is purely propagation — no source-side changes needed. Removes the supply-chain / reproducibility risk of CI behavior shifting under us via main moves.

### [runcycles/.github#62](https://github.com/runcycles/.github/issues/62) — Maven proxy hook no longer destroys `~/.m2/settings.xml`

`.claude/session-start-maven-proxy.sh` previously did a raw `cat > ~/.m2/settings.xml`, wiping any pre-existing mirrors, credentials, or alternate proxy config on every proxied session start. Now: defensively skips the overwrite when the file already exists and prints a stderr note instructing the operator to merge the `<proxies>` block manually if needed.

### [runcycles/.github#63](https://github.com/runcycles/.github/issues/63) — Global deny hook hardening

`.claude/session-start-global-deny.sh` — two fixes:

1. The previous top-level condition (`if grep -q mcp__github__push_files skip; else merge fi`) silently left the policy incomplete if `push_files` was present while one of the other two rules was missing. The `python3` merge is already idempotent, so we now always run it on session start. Removes a whole class of partial-policy bugs.
2. Added `CYCLES_CLAUDE_SKIP_REMOTE_REWRITE` opt-out env var for the Part 2 multi-repo remote rewrite, plus a header comment explaining the multi-repo scope (intentional for Claude Code remote sessions but surprising in isolation).

## Verification

- `bash -n .claude/session-start-maven-proxy.sh` — syntax OK
- `bash -n .claude/session-start-global-deny.sh` — syntax OK
- 3 files changed, +36 / -14
- No behavior change to `cycles-client-java-spring` (no Java touched)

## What's NOT in this PR

- `publish.yaml` SNAPSHOT/tag-version guards — already shipped earlier.
- Other repos in the org with the same files — propagation continues separately.

## Test plan

- [ ] CI green on `@v1`
- [ ] Visual review of the two `.claude/` script diffs
- [ ] Optional: try a Claude Code remote session against this branch and confirm Maven still works + global deny rules still register

## Next steps after merge

Same patches applied to the matching files in:

- `.github/workflows/ci.yml` `@v1` bump: cycles-spring-ai-starter, cycles-server, cycles-server-admin, cycles-server-events, cycles-client-rust, cycles-openai-agents, langchain-runcycles.
- `.claude/session-start-maven-proxy.sh` defensive check: cycles-spring-ai-starter, cycles-server, cycles-server-admin.
- `.claude/session-start-global-deny.sh` hardening: all 13 repos that have the script (full list in the survey from the PR description / issue thread).