### PR TITLE
chore(deps): ignore Spring Boot 4.x bumps + correct dependabot module paths

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,21 @@
 version: 2
 updates:
+  # Maven dependencies — track each module separately since there is no root pom.
   - package-ecosystem: "maven"
-    directory: "/"
+    directories:
+      - "/cycles-client-java-spring"
+      - "/cycles-demo-client-java-spring"
     schedule:
       interval: "weekly"
+    # Stay on the Spring Boot 3.x line per the maintainers policy in
+    # MAINTAINERS.md. Major 4.x bumps require explicit scope review; without
+    # this ignore rule Dependabot re-opens a 4.x PR on every patch release
+    # of Spring Boot 4.
+    ignore:
+      - dependency-name: "org.springframework.boot:*"
+        update-types: ["version-update:semver-major"]
+
+  # GitHub Actions workflow refs.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Two related fixes to `.github/dependabot.yml`.

## 1. Ignore Spring Boot 4.x major bumps

Per MAINTAINERS policy: Spring Boot 3.x is the supported line. Without an `ignore` rule for major bumps, Dependabot re-opens a 4.x PR on every Spring Boot 4 patch release. Minor / patch bumps within 3.x still get tracked.

## 2. Use `directories:` (plural) instead of `directory: /`

The repo's poms live in `cycles-client-java-spring/` and `cycles-demo-client-java-spring/` — there is no root pom. The previous `directory: /` form expects a root pom and may miss the subdirectory poms entirely. The newer `directories: [list]` form (supported by Dependabot since 2024) explicitly enumerates the module paths.

Same fix that landed on cycles-spring-ai-starter as part of the original scaffold review series.