### PR TITLE
chore: hygiene bundle round 2 (#62 + #63 defensive defaults)

### DIFF
--- a/.claude/session-start-global-deny.sh
+++ b/.claude/session-start-global-deny.sh
@@ -62,12 +62,14 @@ fi
 
 # --- Part 2: Fix git remote URLs to use local proxy ---
 # NOTE: This block intentionally rewrites the `origin` remote on EVERY sibling
-# repo under /home/user/* with a github.com remote, not just this one. Claude
-# Code remote sessions clone multiple repos and all need the local git proxy.
-# To opt out (e.g., when running outside that environment, or when you want
-# unrelated checkouts left alone), set CYCLES_CLAUDE_SKIP_REMOTE_REWRITE=1.
-# Tracked org-wide at runcycles/.github#63.
-if [ -n "$CYCLES_CLAUDE_SKIP_REMOTE_REWRITE" ]; then
+# repo under /home/user/* with a github.com remote. That multi-repo scope is
+# only meaningful inside Claude Code's remote sessions (which clone many repos
+# and need them all on the local git proxy). To keep the default safe on
+# vanilla developer machines, we gate on $http_proxy being set — the Claude
+# Code remote env sets that, a vanilla dev machine does not.
+# Explicit override: set CYCLES_CLAUDE_SKIP_REMOTE_REWRITE=1 to skip even when
+# $http_proxy is set. Tracked org-wide at runcycles/.github#63.
+if [ -z "$http_proxy" ] || [ -n "$CYCLES_CLAUDE_SKIP_REMOTE_REWRITE" ]; then
   exit 0
 fi
 

--- a/.claude/session-start-maven-proxy.sh
+++ b/.claude/session-start-maven-proxy.sh
@@ -57,9 +57,14 @@ else
 XMLEOF
 fi
 
-# Install mvn-proxy wrapper that fixes JAVA_TOOL_OPTIONS interference
-MVN_BIN=$(which mvn 2>/dev/null || echo "/opt/maven/bin/mvn")
-cat > /usr/local/bin/mvn-proxy << WRAPEOF
+# Install mvn-proxy wrapper that fixes JAVA_TOOL_OPTIONS interference.
+# Defensively skip if a user-managed wrapper is already present — same etiquette
+# as the ~/.m2/settings.xml check above. Tracked org-wide at runcycles/.github#62.
+if [ -f /usr/local/bin/mvn-proxy ]; then
+  echo "[cycles] /usr/local/bin/mvn-proxy already exists; not overwriting." >&2
+else
+  MVN_BIN=$(which mvn 2>/dev/null || echo "/opt/maven/bin/mvn")
+  cat > /usr/local/bin/mvn-proxy << WRAPEOF
 #!/bin/bash
 # Maven wrapper that fixes proxy auth for Claude Code remote environments.
 # Use 'mvn-proxy' instead of 'mvn' to avoid DNS resolution and proxy auth issues.
@@ -74,4 +79,5 @@ export MAVEN_OPTS="-Dhttps.proxyHost=\$PROXY_HOST -Dhttps.proxyPort=\$PROXY_PORT
 
 exec ${MVN_BIN} -Daether.connector.basic.threads=1 "\$@"
 WRAPEOF
-chmod +x /usr/local/bin/mvn-proxy
+  chmod +x /usr/local/bin/mvn-proxy
+fi


### PR DESCRIPTION
Round 2 of the org-wide hygiene work, addressing the two findings flagged in the 6th review pass on cycles-spring-ai-starter.

## [runcycles/.github#63](https://github.com/runcycles/.github/issues/63) — Multi-repo remote rewrite no longer default-on

Part 2 of `session-start-global-deny.sh` (multi-repo `git remote set-url`) used to run unconditionally, gated only by per-repo content detection (presence of a `local_proxy` URL in any sibling repo). Now: explicitly gated on `$http_proxy` being set, which is the cleanest signal we're inside Claude Code's remote environment. On a vanilla developer machine, `$http_proxy` is unset → Part 2 exits 0 → no mutation.

The `CYCLES_CLAUDE_SKIP_REMOTE_REWRITE` env var still works as an explicit override (e.g., in proxied environments where you specifically want unrelated sibling repos left alone).

## [runcycles/.github#62](https://github.com/runcycles/.github/issues/62) — /usr/local/bin/mvn-proxy no longer clobbered

Same etiquette as the `~/.m2/settings.xml` check applied in round 1: if a user-managed wrapper at that path already exists, leave it alone. Practical impact is low (this location is unusual for user-managed wrappers) but the defensive check costs nothing.

## Verification

`bash -n` passes on both scripts. 2 files, +18 / -10.

## Next

Same patches will propagate to the matching scripts in:
- `session-start-global-deny.sh` (#63 fix): 12 other repos that have the script.
- `session-start-maven-proxy.sh` (#62 fix): cycles-spring-ai-starter, cycles-server, cycles-server-admin.