### PR TITLE
feat(listReservations): lock in from/to ISO-8601 window passthrough (0.2.3)

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,1 @@
--Drevision=0.2.2
+-Drevision=0.2.3

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,7 +1,8 @@
-# Cycles Protocol v0.1.23 — Client (Spring Boot Starter) Audit
+# Cycles Protocol v0.1.25 — Client (Spring Boot Starter) Audit
 
-**Date:** 2026-03-08
-**Spec:** `cycles-protocol-v0.yaml` (OpenAPI 3.1.0, v0.1.23)
+**Date:** 2026-05-21 (v0.2.3 — `from` / `to` ISO-8601 window-filter passthrough on `listReservations` per `cycles-protocol-v0.yaml` revision 2026-05-21; closes the Spring Boot starter side of runcycles/cycles-server#159. No code change — `Map<String, String>` already forwards arbitrary keys; added a regression test on `DefaultCyclesClient` that pins the passthrough. Spring's `WebClient` leaves colons unencoded in the query component (RFC 3986 §3.4-valid), so the wire form is `from=2026-05-21T00:00:00Z`. 433 tests pass; JaCoCo coverage gate met. Version bumped via the single `.mvn/maven.config` source of truth.),
+2026-03-08
+**Spec:** `cycles-protocol-v0.yaml` (OpenAPI 3.1.0, v0.1.25)
 **Client:** `cycles-client-java-spring` (Spring Boot 3.3.5 / Java 21 / WebClient)
 **Server audit:** See `cycles-server/AUDIT.md` (all passing)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,23 @@ The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.
 
 ### Build
 
-- Adopt Maven [CI-friendly versions](https://maven.apache.org/maven-ci-friendly.html). Both poms (`cycles-client-java-spring` and `cycles-demo-client-java-spring`) now declare `<version>${revision}</version>`, and the demo's dependency on the starter uses `<version>${revision}</version>` as well. The single source of truth lives at `.mvn/maven.config` at the repo root (currently `-Drevision=0.2.2`). Cutting a release becomes a one-line edit. Also fixes a drift bug: pre-refactor the demo's pom was at version `0.2.1` and its dep on the starter pinned `0.2.1` while the starter shipped `0.2.2` — they could never have been bumped together without two manual edits.
+- Adopt Maven [CI-friendly versions](https://maven.apache.org/maven-ci-friendly.html). Both poms (`cycles-client-java-spring` and `cycles-demo-client-java-spring`) now declare `<version>${revision}</version>`, and the demo's dependency on the starter uses `<version>${revision}</version>` as well. The single source of truth lives at `.mvn/maven.config` at the repo root (currently `-Drevision=0.2.3`). Cutting a release becomes a one-line edit. Also fixes a drift bug: pre-refactor the demo's pom was at version `0.2.1` and its dep on the starter pinned `0.2.1` while the starter shipped `0.2.2` — they could never have been bumped together without two manual edits.
 - `flatten-maven-plugin` (`resolveCiFriendliesOnly` mode) wired on both poms so install/deploy emit a `.flattened-pom.xml` with `${revision}` substituted to a literal version. Sonatype Central requires a literal in the published `<version>` field; non-CI-friendly properties like `${spring.boot.version}` remain unresolved in the published pom and interpolate against the pom's own `<properties>` block at consumer-resolve time (standard Maven behavior, unchanged).
+
+## [0.2.3] - 2026-05-21
+
+Wire-passthrough verification for the new `from` / `to` query params on `listReservations`. Implements `cycles-protocol-v0.yaml` revision 2026-05-21 ([runcycles/cycles-protocol#97](https://github.com/runcycles/cycles-protocol/pull/97)) on the client side; runcycles/cycles-server#160 ships the server impl. Closes the Spring Boot starter side of runcycles/cycles-server#159.
+
+### Added
+
+- Regression test on `DefaultCyclesClient.listReservations` confirming that `from` / `to` ISO-8601 date-time values are forwarded to the URL query string. The client's `Map<String, String>` signature already accepted these — the test pins the contract so future tightening cannot silently drop them.
+
+### Notes
+
+- Spring's `WebClient` leaves colons unencoded in the query component (RFC 3986 §3.4 permits this), so the wire form is `from=2026-05-21T00:00:00Z` rather than `from=2026-05-21T00%3A00%3A00Z`. Both forms are valid and accepted by cycles-server.
+- No protocol or wire-format change. Servers older than v0.1.25.20 silently ignore the new params per the additive-parameter guarantee in `cycles-protocol-v0.yaml`.
+- 433 tests pass; JaCoCo coverage gate met (≥95% per `CLAUDE.md`).
+- Version bumped on both `cycles-client-java-spring` and `cycles-demo-client-java-spring` poms via the single `.mvn/maven.config` source of truth.
 
 ## [0.2.2] - 2026-05-07
 

--- a/cycles-client-java-spring/pom.xml
+++ b/cycles-client-java-spring/pom.xml
@@ -45,7 +45,7 @@
              this pom and the demo pom, which also resolves ${revision}). The default
              value here is only a fallback for IDE imports that don't pick up
              .mvn/maven.config — the CLI value (or maven.config) always wins. -->
-        <revision>0.2.2</revision>
+        <revision>0.2.3</revision>
 
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>

--- a/cycles-client-java-spring/src/test/java/io/runcycles/client/java/spring/client/DefaultCyclesClientTest.java
+++ b/cycles-client-java-spring/src/test/java/io/runcycles/client/java/spring/client/DefaultCyclesClientTest.java
@@ -244,6 +244,30 @@ class DefaultCyclesClientTest {
             assertThat(path).contains("status=ACTIVE");
             assertThat(path).contains("tenant=t1");
         }
+
+        // cycles-protocol-v0.yaml revision 2026-05-21 — from/to ISO-8601
+        // window-filter passthrough. The existing Map<String,String> signature
+        // already accepts the new params; this test pins the contract so future
+        // tightening cannot drop them silently. Spring's WebClient leaves
+        // colons unencoded in the query string (RFC 3986 §3.4 permits `:` in
+        // the query component), so we assert the raw ISO-8601 form.
+        @Test
+        void shouldForwardFromToWindowFilter() throws Exception {
+            enqueueJson(200, Map.of("reservations", java.util.List.of()));
+
+            client.listReservations(Map.of(
+                "tenant", "acme",
+                "from", "2026-05-21T00:00:00Z",
+                "to", "2026-05-22T00:00:00Z"
+            ));
+
+            RecordedRequest req = server.takeRequest();
+            assertThat(req.getMethod()).isEqualTo("GET");
+            String path = req.getPath();
+            assertThat(path).contains("tenant=acme");
+            assertThat(path).contains("from=2026-05-21T00:00:00Z");
+            assertThat(path).contains("to=2026-05-22T00:00:00Z");
+        }
     }
 
     @Nested

--- a/cycles-demo-client-java-spring/pom.xml
+++ b/cycles-demo-client-java-spring/pom.xml
@@ -16,7 +16,7 @@
         <!-- See cycles-client-java-spring/pom.xml for the canonical comment. The demo
              reads the same ${revision} so its dependency on the starter (below) and
              its own <version> bump in lockstep with the starter. -->
-        <revision>0.2.2</revision>
+        <revision>0.2.3</revision>
 
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
## Summary

Client-side companion to [cycles-protocol-v0.yaml revision 2026-05-21](https://github.com/runcycles/cycles-protocol/pull/97) and [cycles-server#160](https://github.com/runcycles/cycles-server/pull/160) (which together added `from` / `to` ISO-8601 window-filter query params to `GET /v1/reservations`). Matches the same shape we landed in runcycles/cycles-client-python#66, runcycles/cycles-client-typescript#103, and runcycles/cycles-client-rust#39.

## What this PR does

`DefaultCyclesClient.listReservations(Map<String, String>)` is already permissive — it forwards arbitrary keys to the URL query string. So `from` / `to` work over the wire today, no code change. This PR:

- Adds a **regression test** on `DefaultCyclesClient.listReservations` (`cycles-client-java-spring/src/test/java/.../DefaultCyclesClientTest.java`) confirming the new ISO-8601 params land in the GET path. Pins the contract so future tightening of the `Map` signature cannot silently drop the new keys.
- Bumps `revision` from **0.2.2 → 0.2.3** via the single `.mvn/maven.config` source of truth (propagates to both `cycles-client-java-spring` and `cycles-demo-client-java-spring` poms — the drift-protection invariant from the CI-friendly-versions refactor in `[Unreleased]`).
- Updates `AUDIT.md` and `CHANGELOG.md`.

## Wire-format note

Spring's `WebClient` leaves colons unencoded in the query component (RFC 3986 §3.4 permits this), so the emitted path is:

```
/v1/reservations?from=2026-05-21T00:00:00Z&to=2026-05-22T00:00:00Z&tenant=acme
```

— not the percent-escaped form. cycles-server accepts both shapes; the test asserts the literal WebClient output.

## Call-site syntax

```java
client.listReservations(Map.of(
    "tenant", "acme",
    "from",   "2026-05-21T00:00:00Z",
    "to",     "2026-05-22T00:00:00Z"
));
```

No reserved-keyword issue (unlike Python where `from` requires a dict-unpack workaround).

## Verification

- `mvn -B verify --file cycles-client-java-spring/pom.xml`: **433 tests pass**.
- JaCoCo coverage gate met (`[INFO] All coverage checks have been met.`) per the project's ≥95% rule.

## Test plan

- [ ] CI green
- [ ] (After merge) optional smoke against a v0.1.25.20 cycles-server with a windowed `listReservations` call

## Out of scope

- The client's permissive `Map<String, String>` signature is left as-is; a typed `ListReservationsParams` would be a separate ergonomic discussion (parallel to the Rust client's existing strongly-typed pattern).

Closes the Spring Boot starter side of the issue cluster for runcycles/cycles-server#159.
