### PR TITLE
docs: finalize 0.2.5 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.
 
 ## [Unreleased]
 
+## [0.2.5] - 2026-06-18
+
 ### Added
 
 - Add declarative commit metadata binding via `@Cycles(metadata = "...")`. The SpEL expression is evaluated at commit time against the guarded method invocation, must produce a `Map<String,Object>`, and is merged with `CyclesContextHolder` commit metadata, with programmatic metadata taking precedence on duplicate keys. Implements [#88](https://github.com/runcycles/cycles-spring-boot-starter/issues/88).


### PR DESCRIPTION
## Summary
- Move the merged 0.2.5 changelog content out of `[Unreleased]`
- Add the dated `## [0.2.5] - 2026-06-18` release section

## Verification
- `git diff --check`