### PR TITLE
docs: add metadata root getter javadocs

### DIFF
--- a/cycles-client-java-spring/src/main/java/io/runcycles/client/java/spring/evaluation/CyclesExpressionEvaluator.java
+++ b/cycles-client-java-spring/src/main/java/io/runcycles/client/java/spring/evaluation/CyclesExpressionEvaluator.java
@@ -201,18 +201,38 @@ public class CyclesExpressionEvaluator {
             this.method = method;
         }
 
+        /**
+         * Returns the bean instance on which the annotated method was invoked.
+         *
+         * @return the target bean instance
+         */
         public Object getTarget() {
             return target;
         }
 
+        /**
+         * Returns the annotated method invocation arguments.
+         *
+         * @return the method invocation arguments
+         */
         public Object[] getArgs() {
             return args;
         }
 
+        /**
+         * Returns the annotated method return value.
+         *
+         * @return the method return value
+         */
         public Object getResult() {
             return result;
         }
 
+        /**
+         * Returns the annotated method.
+         *
+         * @return the annotated method
+         */
         public Method getMethod() {
             return method;
         }


### PR DESCRIPTION
## Summary
- Add Javadocs for `MethodInvocationRoot` public getters
- Eliminate release-build Javadoc warnings for the metadata SpEL root object

## Verification
- `git diff --check`
- PR CI run 155 passed
- Manual release-profile workflow run 27794570701 passed on this branch
- Searched the release-profile job log for `Javadoc Warnings`, `no comment`, and `warning:`. The previous Javadoc `no comment` warnings are gone; remaining warnings are unrelated JVM dynamic-agent warnings from test execution.
- Local `mvn -B -Prelease -DskipTests javadoc:javadoc` could not complete because dependency resolution from Maven Central fails in this environment with `PKIX path building failed` before Javadoc generation starts.